### PR TITLE
initialize func without noise input

### DIFF
--- a/experiments/surface_fluxes_perfect_model/Manifest.toml
+++ b/experiments/surface_fluxes_perfect_model/Manifest.toml
@@ -186,7 +186,7 @@ weakdeps = ["SparseArrays"]
 deps = ["Distributions", "EnsembleKalmanProcesses", "JLD2", "Random", "TOML", "YAML"]
 path = "../.."
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.0.1"
+version = "0.0.2"
 
     [deps.ClimaCalibrate.extensions]
     CESExt = "CalibrateEmulateSample"

--- a/src/slurm.jl
+++ b/src/slurm.jl
@@ -71,7 +71,7 @@ function wait_for_jobs(
                     push!(completed_jobs, m)
                 end
             end
-            sleep(10)
+            sleep(5)
         end
     catch e
         kill_job.(jobids)


### PR DESCRIPTION
Add a new `initialize` method to work with EKP `ObservationSeries`. This may not be merged, since it is just a quickfix for now