### PR TITLE
Enable early termination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts
-          PYTHON: ""
         with:
           path: ~/.julia/artifacts
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -317,8 +317,8 @@ function update_ensemble(output_dir::AbstractString, iteration, prior)
 
     # Load data from the ensemble
     G_ens = JLD2.load_object(joinpath(iter_path, "G_ensemble.jld2"))
-    EKP.update_ensemble!(eki, G_ens)
 
+    terminate = EKP.update_ensemble!(eki, G_ens)
     save_eki_state(eki, output_dir, iteration + 1, prior)
-    return eki
+    return terminate
 end


### PR DESCRIPTION
This PR changes `update_ensemble` to return the termination flag passed by EKP, which is in turn checked with `!isnothing(terminate)`. 

Closes #104 