### PR TITLE
Fix JuliaBackend `calibrate` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCalibrate"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 authors = ["Climate Modeling Alliance"]
-version = "0.0.4"
+version = "0.0.5"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -268,10 +268,11 @@ function _initialize(
     initial_ensemble =
         EKP.construct_initial_ensemble(rng_ekp, prior, ensemble_size)
 
+    ekp_str_kwargs = Dict([string(k) => v for (k, v) in ekp_kwargs])
     eki_constructor =
         (args...) -> EKP.EnsembleKalmanProcess(
             args...,
-            Dict(EKP.default_options_dict(EKP.Inversion())..., ekp_kwargs...);
+            merge(EKP.default_options_dict(EKP.Inversion()), ekp_str_kwargs);
             rng = rng_ekp,
         )
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CalibrateEmulateSample = "95e48a1f-0bec-4818-9538-3db4340308e3"
 ClimaCalibrate = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
@@ -12,3 +11,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+EnsembleKalmanProcesses = "2"

--- a/test/pure_julia_e2e.jl
+++ b/test/pure_julia_e2e.jl
@@ -77,7 +77,7 @@ ekp = calibrate(JuliaBackend, experiment_config)
     parameter_values =
         [EKP.get_ϕ_mean(prior, ekp, it) for it in 1:(n_iterations + 1)]
     @test parameter_values[1][1] ≈ 8.507 rtol = 0.01
-    @test parameter_values[end][1] ≈ 19.0124 rtol = 0.01
+    @test parameter_values[end][1] ≈ 11.852161842745355 rtol = 0.01
 end
 
 rm(output_dir; recursive = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 
 include("ekp_interface.jl")
 include("model_interface.jl")
-include("emulate_sample.jl")
+# Disabled since we use EKP 2.0 in testing, CES is still incompatible with EKP 2.0
+# include("emulate_sample.jl")
 include("pure_julia_e2e.jl")
 include("aqua.jl")


### PR DESCRIPTION

- Add `calibrate(; ekp = ekp::EnsembleKalmanProcess)` functionality
- Improve keyword tests