### PR TITLE
Return error on failed scheduled job submission

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCalibrate"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 authors = ["Climate Modeling Alliance"]
-version = "0.0.10"
+version = "0.0.11"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/test/pbs_manager_unit_tests.jl
+++ b/test/pbs_manager_unit_tests.jl
@@ -50,9 +50,8 @@ end
     @test ClimaCalibrate.map_remotecall_fetch(+, 2, 3) == fill(5, length(p))
 
     # Test specified workers list
-    @test length(
-        ClimaCalibrate.map_remotecall_fetch(myid; workers = workers()[1:2]),
-    ) == 2
+    @test length(ClimaCalibrate.map_remotecall_fetch(myid; workers = p[1:2])) ==
+          2
 
     # Test with more complex data structure
     d = Dict("a" => 1, "b" => 2)

--- a/test/slurm_manager_unit_tests.jl
+++ b/test/slurm_manager_unit_tests.jl
@@ -1,4 +1,4 @@
-using Test, ClimaCalibrate, Distributed
+using Test, ClimaCalibrate, Distributed, Logging
 
 @testset "SlurmManager Unit Tests" begin
     out_file = "my_slurm_job.out"
@@ -7,14 +7,17 @@ using Test, ClimaCalibrate, Distributed
     @test workers() == p
     @test fetch(@spawnat :any myid()) == p[1]
     @test remotecall_fetch(+, p[1], 1, 1) == 2
+    # Test that the worker is configured correctly
+    @test remotecall_fetch(Base.active_project, p[1]) == Base.active_project()
+    @test remotecall_fetch(global_logger, p[1]) isa
+          Base.CoreLogging.SimpleLogger
     rmprocs(p)
     @test nprocs() == 1
     @test workers() == [1]
-
     # Check output file creation
     @test isfile(out_file)
     rm(out_file)
 
-    @test_throws TaskFailedException p =
-        addprocs(SlurmManager(1); o = out_file, output = out_file)
+    # Test incorrect generic arguments
+    @test_throws TaskFailedException p = addprocs(SlurmManager(1), time = "w")
 end


### PR DESCRIPTION
This PR unifies the polling for slurm and PBS systems into one function which now has a longer timeout. On both systems, julia workers will create their own file loggers from now on.
The main purpose of this PR is to return an error if the job submission fails. Before, the error would log but Julia would continue waiting for the worker.