### PR TITLE
Add support for asynchronous workers

### DIFF
--- a/docs/literate_example.jl
+++ b/docs/literate_example.jl
@@ -167,7 +167,8 @@ observations .= process_member_data(SimDir(simulation.output_dir))
 # The simplest backend is the `JuliaBackend`, which runs all ensemble members sequentially and does not require `Distributed.jl`.
 # For more information, see the [`Backends`](https://clima.github.io/ClimaCalibrate.jl/dev/backends/) page.
 eki = CAL.calibrate(
-    CAL.WorkerBackend,
+    CAL.JuliaBackend,
+    #md # CAL.WorkerBackend # We can't use this backend in Literate.jl
     ensemble_size,
     n_iterations,
     observations,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -52,6 +52,7 @@ ClimaCalibrate.submit_pbs_job
 ClimaCalibrate.initialize
 ClimaCalibrate.save_G_ensemble
 ClimaCalibrate.update_ensemble
+ClimaCalibrate.update_ensemble!
 ClimaCalibrate.ExperimentConfig
 ClimaCalibrate.get_prior
 ClimaCalibrate.get_param_dict

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -292,7 +292,7 @@ function calibrate(
         noise;
         ekp_kwargs...,
     )
-    return calibrate(b, eki, n_iterations, prior, output_dir; worker_pool)
+    return calibrate(b, eki, n_iterations, prior, output_dir)
 end
 
 function calibrate(

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -257,7 +257,6 @@ function calibrate(
     b::Type{WorkerBackend},
     config::ExperimentConfig;
     failure_rate = DEFAULT_FAILURE_RATE,
-    worker_pool = default_worker_pool(),
     ekp_kwargs...,
 )
     (; ensemble_size, n_iterations, observations, noise, prior, output_dir) =
@@ -271,7 +270,6 @@ function calibrate(
         prior,
         output_dir;
         failure_rate,
-        worker_pool,
         ekp_kwargs...,
     )
 end
@@ -285,7 +283,6 @@ function calibrate(
     prior,
     output_dir;
     failure_rate = DEFAULT_FAILURE_RATE,
-    worker_pool = default_worker_pool(),
     ekp_kwargs...,
 )
     eki = ekp_constructor(
@@ -305,7 +302,6 @@ function calibrate(
     prior,
     output_dir;
     failure_rate = DEFAULT_FAILURE_RATE,
-    worker_pool = default_worker_pool(),
 )
     ekp = initialize(ekp, prior, output_dir)
     ensemble_size = EKP.get_N_ens(ekp)
@@ -317,7 +313,6 @@ function calibrate(
             iter,
             ensemble_size,
             output_dir;
-            worker_pool,
             failure_rate,
         )
         @info "Iteration $iter time: $time"

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -1,42 +1,50 @@
 using Distributed
 using Logging
 
-export SlurmManager, PBSManager, default_worker_pool, set_worker_loggers
+export SlurmManager, PBSManager, set_worker_loggers
 
-# Set the time limit for the Julia worker to be contacted by the main process, default = "60.0s"
-# https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_WORKER_TIMEOUT
-worker_timeout() = "300.0"
-ENV["JULIA_WORKER_TIMEOUT"] = worker_timeout()
-
-default_worker_pool() = WorkerPool(workers())
+get_worker_pool() = workers() == [1] ? WorkerPool() : default_worker_pool()
 
 function run_worker_iteration(
     iter,
     ensemble_size,
     output_dir;
-    worker_pool = default_worker_pool(),
     failure_rate = DEFAULT_FAILURE_RATE,
 )
-    # Create a channel to collect results
-    results = Channel{Any}(ensemble_size)
     nfailures = 0
-    @sync begin
-        for m in 1:(ensemble_size)
-            @async begin
-                worker = take!(worker_pool)
-                @info "Running particle $m on worker $worker"
-                try
-                    remotecall_wait(forward_model, worker, iter, m)
-                catch e
-                    @warn "Error running member $m" exception = e
-                    nfailures += 1
-                finally
-                    # Always return worker to pool
-                    put!(worker_pool, worker)
-                end
-            end
+    worker_pool = get_worker_pool()
+    all_known_workers = get_worker_pool()
+
+    work_to_do = map(1:ensemble_size) do m
+        (w) -> begin
+            @info "Running particle $m on worker $w"
+            remotecall_wait(forward_model, w, iter, m)
         end
     end
+
+    @sync while !isempty(work_to_do)
+        # Add new workers to worker_pool
+        all_workers = get_worker_pool()
+        new_workers = setdiff(all_workers.workers, all_known_workers.workers)
+        foreach(x -> push!(worker_pool, x), new_workers)
+        all_known_workers = all_workers
+        if !isempty(worker_pool.workers)
+            worker = take!(worker_pool)
+            run_fwd_model = pop!(work_to_do)
+            @async try
+                run_fwd_model(worker)
+            catch e
+                @warn "Error running on worker $worker" exception = e
+                nfailures += 1
+            finally
+                push!(worker_pool, worker)
+            end
+        else
+            println("no workers available")
+            sleep(10) # Wait for workers to become available
+        end
+    end
+
     iter_failure_rate = nfailures / ensemble_size
     if iter_failure_rate > failure_rate
         error(
@@ -78,7 +86,7 @@ struct SlurmManager <: ClusterManager
 
     function SlurmManager(
         ntasks = parse(Int, get(ENV, "SLURM_NTASKS", "1"));
-        expr = :()
+        expr = :(),
     )
         new(ntasks, expr)
     end
@@ -312,10 +320,7 @@ struct PBSManager <: ClusterManager
     ntasks::Integer
     expr::Expr
 
-    function PBSManager(
-        ntasks;
-        expr = :()
-    )
+    function PBSManager(ntasks; expr = :())
         new(ntasks, expr)
     end
 end

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -3,6 +3,8 @@ using Logging
 
 export SlurmManager, PBSManager, set_worker_loggers
 
+worker_timeout() = parse(Float64, get(ENV, "JULIA_WORKER_TIMEOUT", "300.0"))
+
 get_worker_pool() = workers() == [1] ? WorkerPool() : default_worker_pool()
 
 function run_worker_iteration(
@@ -21,7 +23,7 @@ function run_worker_iteration(
             remotecall_wait(forward_model, w, iter, m)
         end
     end
-
+    isempty(all_known_workers.workers) && @info "No workers currently available"
     @sync while !isempty(work_to_do)
         # Add new workers to worker_pool
         all_workers = get_worker_pool()
@@ -40,7 +42,7 @@ function run_worker_iteration(
                 push!(worker_pool, worker)
             end
         else
-            println("no workers available")
+            @debug "no workers available"
             sleep(10) # Wait for workers to become available
         end
     end
@@ -75,7 +77,7 @@ addprocs(SlurmManager(ntasks=4))
 
 # Pass additional arguments to `srun`
 addprocs(SlurmManager(ntasks=4), gpus_per_task=1)
-
+```
 # Related functions
 - `calibrate(WorkerBackend, ...)`: Perform calibration using workers
 - `remotecall(func, worker_id, args...)`: Execute functions on specific workers
@@ -100,7 +102,6 @@ function Distributed.manage(
 )
     if op == :register
         set_worker_logger(id)
-        evaluate_initial_expression(id, manager.expr)
     end
 end
 
@@ -313,8 +314,6 @@ Workers inherit the current Julia environment by default.
 # Related Functions
 - `calibrate(WorkerBackend, ...)`: Perform worker calibration
 - `remotecall(func, worker_id, args...)`: Execute functions on specific workers
-
-See also: [`addprocs`](@ref), [`Distributed`](@ref), [`SlurmManager`](@ref)
 """
 struct PBSManager <: ClusterManager
     ntasks::Integer
@@ -457,6 +456,7 @@ This function should be called from the worker process.
 """
 function set_worker_logger()
     @eval Main using Logging
+    redirect_stderr(stdout)
     io = open("worker_$(myid()).log", "w")
     logger = SimpleLogger(io)
     Base.global_logger(logger)
@@ -477,4 +477,149 @@ function set_worker_loggers(workers = workers())
             ClimaCalibrate.set_worker_logger()
         end
     end
+end
+
+# Copied from Distributed.jl in order to evaluate the manager's expression on worker initialization
+function Distributed.create_worker(
+    manager::Union{SlurmManager, PBSManager},
+    wconfig,
+)
+    # only node 1 can add new nodes, since nobody else has the full list of address:port
+    @assert Distributed.LPROC.id == 1
+    timeout = worker_timeout()
+
+    # initiate a connect. Does not wait for connection completion in case of TCP.
+    w = Distributed.Worker()
+    local r_s, w_s
+    try
+        (r_s, w_s) = Distributed.connect(manager, w.id, wconfig)
+    catch ex
+        try
+            Distributed.deregister_worker(w.id)
+            kill(manager, w.id, wconfig)
+        finally
+            rethrow(ex)
+        end
+    end
+
+    w = Distributed.Worker(w.id, r_s, w_s, manager; config = wconfig)
+    # install a finalizer to perform cleanup if necessary
+    finalizer(w) do w
+        if myid() == 1
+            Distributed.manage(w.manager, w.id, w.config, :finalize)
+        end
+    end
+
+    # set when the new worker has finished connections with all other workers
+    ntfy_oid = Distributed.RRID()
+    rr_ntfy_join = Distributed.lookup_ref(ntfy_oid)
+    rr_ntfy_join.waitingfor = myid()
+
+    # Start a new task to handle inbound messages from connected worker in master.
+    # Also calls `wait_connected` on TCP streams.
+    Distributed.process_messages(w.r_stream, w.w_stream, false)
+
+    # send address information of all workers to the new worker.
+    # Cluster managers set the address of each worker in `WorkerConfig.connect_at`.
+    # A new worker uses this to setup an all-to-all network if topology :all_to_all is specified.
+    # Workers with higher pids connect to workers with lower pids. Except process 1 (master) which
+    # initiates connections to all workers.
+
+    # Connection Setup Protocol:
+    # - Master sends 16-byte cookie followed by 16-byte version string and a JoinPGRP message to all workers
+    # - On each worker
+    #   - Worker responds with a 16-byte version followed by a JoinCompleteMsg
+    #   - Connects to all workers less than its pid. Sends the cookie, version and an IdentifySocket message
+    #   - Workers with incoming connection requests write back their Version and an IdentifySocketAckMsg message
+    # - On master, receiving a JoinCompleteMsg triggers rr_ntfy_join (signifies that worker setup is complete)
+
+    join_list = []
+    if Distributed.PGRP.topology === :all_to_all
+        # need to wait for lower worker pids to have completed connecting, since the numerical value
+        # of pids is relevant to the connection process, i.e., higher pids connect to lower pids and they
+        # require the value of config.connect_at which is set only upon connection completion
+        for jw in Distributed.PGRP.workers
+            if (jw.id != 1) && (jw.id < w.id)
+                # wait for wl to join
+                # We should access this atomically using (@atomic jw.state) 
+                # but this is only recently supported
+                if jw.state === Distributed.W_CREATED
+                    lock(jw.c_state) do
+                        wait(jw.c_state)
+                    end
+                end
+                push!(join_list, jw)
+            end
+        end
+
+    elseif Distributed.PGRP.topology === :custom
+        # wait for requested workers to be up before connecting to them.
+        filterfunc(x) =
+            (x.id != 1) &&
+            isdefined(x, :config) &&
+            (
+                notnothing(x.config.ident) in
+                something(wconfig.connect_idents, [])
+            )
+
+        wlist = filter(filterfunc, Distributed.PGRP.workers)
+        waittime = 0
+        while wconfig.connect_idents !== nothing &&
+            length(wlist) < length(wconfig.connect_idents)
+            if waittime >= timeout
+                error("peer workers did not connect within $timeout seconds")
+            end
+            sleep(1.0)
+            waittime += 1
+            wlist = filter(filterfunc, Distributed.PGRP.workers)
+        end
+
+        for wl in wlist
+            lock(wl.c_state) do
+                if (@atomic wl.state) === Distributed.W_CREATED
+                    # wait for wl to join
+                    wait(wl.c_state)
+                end
+            end
+            push!(join_list, wl)
+        end
+    end
+
+    all_locs = Base.mapany(
+        x ->
+            isa(x, Distributed.Worker) ?
+            (something(x.config.connect_at, ()), x.id) : ((), x.id, true),
+        join_list,
+    )
+    Distributed.send_connection_hdr(w, true)
+    enable_threaded_blas = something(wconfig.enable_threaded_blas, false)
+
+    join_message = Distributed.JoinPGRPMsg(
+        w.id,
+        all_locs,
+        Distributed.PGRP.topology,
+        enable_threaded_blas,
+        Distributed.isclusterlazy(),
+    )
+    Distributed.send_msg_now(
+        w,
+        Distributed.MsgHeader(Distributed.RRID(0, 0), ntfy_oid),
+        join_message,
+    )
+
+    # Ensure the initial expression is evaluated before any other code
+    @info "Evaluating initial expression on worker $(w.id)"
+    evaluate_initial_expression(w.id, manager.expr)
+
+    @async Distributed.manage(w.manager, w.id, w.config, :register)
+
+    # wait for rr_ntfy_join with timeout
+    if timedwait(() -> isready(rr_ntfy_join), timeout) === :timed_out
+        error("worker did not connect within $timeout seconds")
+    end
+    lock(Distributed.client_refs) do
+        delete!(Distributed.PGRP.refs, ntfy_oid)
+    end
+
+    return w.id
 end

--- a/test/pbs_manager_unit_tests.jl
+++ b/test/pbs_manager_unit_tests.jl
@@ -21,9 +21,12 @@ using Test, ClimaCalibrate, Distributed, Logging
     rmprocs(p)
     @test nprocs() == 1
     @test workers() == [1]
+
+    # Test broken arguments
+    @test_throws TaskFailedException p = addprocs(PBSManager(1), time = "w")
 end
 
-@testset "PBSManager - multiple processes" begin
+@testset "Test PBSManager multiple tasks, output file" begin
     out_file = "pbs_unit_test.out"
     p = addprocs(
         PBSManager(2),
@@ -36,34 +39,6 @@ end
     @test nprocs() == length(p) + 1
     @test workers() == p
     @test remotecall_fetch(+, p[1], 1, 1) == 2
-
-    @everywhere using ClimaCalibrate
-    # Test function with no arguments
-    p = workers()
-    @test ClimaCalibrate.map_remotecall_fetch(myid) == p
-
-    # single argument 
-    x = rand(5)
-    @test ClimaCalibrate.map_remotecall_fetch(identity, x) == fill(x, length(p))
-
-    # multiple arguments
-    @test ClimaCalibrate.map_remotecall_fetch(+, 2, 3) == fill(5, length(p))
-
-    # Test specified workers list
-    @test length(ClimaCalibrate.map_remotecall_fetch(myid; workers = p[1:2])) ==
-          2
-
-    # Test with more complex data structure
-    d = Dict("a" => 1, "b" => 2)
-    @test ClimaCalibrate.map_remotecall_fetch(identity, d) == fill(d, length(p))
-
-    loggers = ClimaCalibrate.set_worker_loggers()
-    @test length(loggers) == length(p)
-    @test typeof(loggers) == Vector{Base.CoreLogging.SimpleLogger}
-
-    rmprocs(p)
-    @test nprocs() == 1
-    @test workers() == [1]
 
     @test isfile(out_file)
     rm(out_file)

--- a/test/slurm_manager_unit_tests.jl
+++ b/test/slurm_manager_unit_tests.jl
@@ -2,7 +2,13 @@ using Test, ClimaCalibrate, Distributed, Logging
 
 @testset "SlurmManager Unit Tests" begin
     out_file = "my_slurm_job.out"
-    p = addprocs(SlurmManager(1); o = out_file)
+    initial_expr = quote
+        @info "Running worker $(myid())"
+        using Test
+        using LinearAlgebra
+    end
+    p = addprocs(SlurmManager(1; expr = initial_expr); o = out_file)
+
     @test nprocs() == 2
     @test workers() == p
     @test fetch(@spawnat :any myid()) == p[1]

--- a/test/slurm_manager_unit_tests.jl
+++ b/test/slurm_manager_unit_tests.jl
@@ -27,3 +27,49 @@ using Test, ClimaCalibrate, Distributed, Logging
     # Test incorrect generic arguments
     @test_throws TaskFailedException p = addprocs(SlurmManager(1), time = "w")
 end
+
+@testset "SlurmManager Initialization Expressions" begin
+    p = addprocs(SlurmManager(1; expr = :(@info "test")))
+    rmprocs(p)
+    test_logger = TestLogger()
+    with_logger(test_logger) do
+        p = addprocs(SlurmManager(1; expr = :(w + 2)))
+        rmprocs(p)
+    end
+    @test test_logger.logs[end].message == "Initial worker expression errored:"
+end
+
+@testset "Test remotecall utilities" begin
+    p = addprocs(SlurmManager(2))
+    @test nprocs() == length(p) + 1
+    @test workers() == p
+    @test remotecall_fetch(+, p[1], 1, 1) == 2
+
+    @everywhere using ClimaCalibrate
+    # Test function with no arguments
+    p = workers()
+    @test ClimaCalibrate.map_remotecall_fetch(myid) == p
+
+    # single argument 
+    x = rand(5)
+    @test ClimaCalibrate.map_remotecall_fetch(identity, x) == fill(x, length(p))
+
+    # multiple arguments
+    @test ClimaCalibrate.map_remotecall_fetch(+, 2, 3) == fill(5, length(p))
+
+    # Test specified workers list
+    @test length(ClimaCalibrate.map_remotecall_fetch(myid; workers = p[1:2])) ==
+          2
+
+    # Test with more complex data structure
+    d = Dict("a" => 1, "b" => 2)
+    @test ClimaCalibrate.map_remotecall_fetch(identity, d) == fill(d, length(p))
+
+    loggers = ClimaCalibrate.set_worker_loggers()
+    @test length(loggers) == length(p)
+    @test typeof(loggers) == Vector{Base.CoreLogging.SimpleLogger}
+
+    rmprocs(p)
+    @test nprocs() == 1
+    @test workers() == [1]
+end

--- a/test/worker_backend.jl
+++ b/test/worker_backend.jl
@@ -9,17 +9,29 @@ include(
     ),
 )
 
+# Expression to run on worker initialization, used instead of @everywhere
+expr = quote
+    include(
+        joinpath(
+            pkgdir(ClimaCalibrate),
+            "experiments",
+            "surface_fluxes_perfect_model",
+            "model_interface.jl",
+        ),
+    )
+end
+
 if nworkers() == 1
     if get_backend() == ClimaCalibrate.DerechoBackend
-        addprocs(
-            PBSManager(5),
+        @async addprocs(
+            PBSManager(5; expr),
             q = "preempt",
             A = "UCIT0011",
             l_select = "1:ncpus=1:ngpus=1",
             l_walltime = "00:30:00",
         )
     else
-        addprocs(SlurmManager(5))
+        @async addprocs(SlurmManager(5; expr))
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR enables workers to be added while a calibration is already underway.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->

- [ ] Add `redirect_stderr(stdout)` to worker logger func

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add an `expr` field to PBSManager and SlurmManager. This `expr` is evaluated just after the worker is initialized. This can be set via `SlurmManager(nprocs; expr)`. This enables workers to be initialized and load code asynchronously, without relying on `@everywhere`.
- Add method specialization for `Distributed.create_worker(manager::Union{SlurmManager, PBSManager},...)` in order to ensure the expression gets evaluated before any other code.
- Changed `run_worker_iteration` to check for newly added workers for each forward model run. The function now gets initial workers, then makes a vector of work (fwd model calls). While this vector is not empty, we check for new workers, and if workers are available we assign one unit of work to the worker. If no workers are available, wait for workers

Previous workflow:
```julia
addprocs(SlurmManager(nprocs)...)
@everywhere
    include(model_interface_file)
end

calibrate(WorkerBackend, ...)
```
New workflow:
```julia
expr = quote
    include(model_interface_file)
end
@async addprocs(SlurmManager(nprocs; expr)...)

calibrate(WorkerBackend, ...)
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
