### PR TITLE
Add default function to add workers

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,6 +11,7 @@ ClimaCalibrate.postprocess_g_ensemble
 
 ## Worker Interface
 ```@docs
+ClimaCalibrate.add_workers
 ClimaCalibrate.WorkerBackend
 ClimaCalibrate.SlurmManager
 ClimaCalibrate.PBSManager

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -34,6 +34,8 @@ Used for CliMA's private GPU server.
 """
 struct ClimaGPUBackend <: SlurmBackend end
 
+struct GCPBackend <: SlurmBackend end
+
 """
     DerechoBackend
 
@@ -61,6 +63,8 @@ function get_backend()
         (r"^clima.gps.caltech.edu$", ClimaGPUBackend),
         (r"^login[1-4].cm.cluster$", CaltechHPCBackend),
         (r"^hpc-(\d\d)-(\d\d).cm.cluster$", CaltechHPCBackend),
+        (r"^hpc\d+-slurm-login-\d+$", GCPBackend),
+        (r"^hpc\d+-a\d+nodeset-\d+$", GCPBackend),
         (r"derecho([1-8])$", DerechoBackend),
         (r"deg(\d\d\d\d)$", DerechoBackend), # This should be more specific
     ]

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -438,3 +438,9 @@ function model_run(
     end
     return job_id
 end
+
+backend_worker_kwargs(::Type{DerechoBackend}) = (; q = "main", A = "UCIT0011")
+
+backend_worker_kwargs(::Type{GCPBackend}) = (; partition = "a3")
+
+backend_worker_kwargs(::Type{<:AbstractBackend}) = (;)

--- a/test/hpc_backend.jl
+++ b/test/hpc_backend.jl
@@ -17,7 +17,7 @@ if backend == DerechoBackend
 end
 
 original_model_interface = model_interface
-interruption_model_interface, io = mktemp()
+interruption_model_interface, io = mktemp(@__DIR__)
 model_interface_str = """
 import ClimaCalibrate
 ClimaCalibrate.forward_model(iter, member) = member == 1 && exit()

--- a/test/pbs_manager_unit_tests.jl
+++ b/test/pbs_manager_unit_tests.jl
@@ -1,13 +1,8 @@
 using Test, ClimaCalibrate, Distributed, Logging
 
 @testset "PBSManager Unit Tests" begin
-    p = addprocs(
-        PBSManager(1),
-        q = "main",
-        A = "UCIT0011",
-        l_select = "ngpus=1",
-        l_walltime = "00:05:00",
-    )
+    @test ClimaCalibrate.get_manager() == PBSManager(1)
+    p = add_workers(1; l_walltime = "00:05:00")
     @test nprocs() == length(p) + 1
     @test workers() == p
     @test remotecall_fetch(myid, 2) == 2

--- a/test/slurm_manager_unit_tests.jl
+++ b/test/slurm_manager_unit_tests.jl
@@ -1,8 +1,9 @@
 using Test, ClimaCalibrate, Distributed, Logging
 
 @testset "SlurmManager Unit Tests" begin
-    out_file = "my_slurm_job.out"
-    p = addprocs(SlurmManager(1); o = out_file)
+    @test ClimaCalibrate.get_manager() == SlurmManager(1)
+    out_file = tempname()
+    p = add_workers(1; device = :cpu, o = out_file)
     @test nprocs() == 2
     @test workers() == p
     @test fetch(@spawnat :any myid()) == p[1]
@@ -16,7 +17,6 @@ using Test, ClimaCalibrate, Distributed, Logging
     @test workers() == [1]
     # Check output file creation
     @test isfile(out_file)
-    rm(out_file)
 
     # Test incorrect generic arguments
     @test_throws TaskFailedException p = addprocs(SlurmManager(1), time = "w")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds a function `add_workers` that provides user-friendly defaults. Closes #170 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

- Added `GCPBackend`
- Added `add_workers(nworkers; device = :gpu, cluster_type = :auto, kwargs...)`, which automatically detects the manager and supplies default kwargs for the compute environment.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
