### PR TITLE
Add minibatch helper functions

### DIFF
--- a/.github/workflows/julia_formatter.yml
+++ b/.github/workflows/julia_formatter.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v3
         with:
-          version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
+          version: '2' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,7 @@ makedocs(
         "Getting Started" => "quickstart.md",
         "Distributed Calibration Tutorial" => "literate_example.md",
         "Backends" => "backends.md",
+        "Observations" => "observations.md",
         "Emulate and Sample" => "emulate_sample.md",
         "API" => "api.md",
     ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -63,4 +63,6 @@ ClimaCalibrate.path_to_iteration
 ClimaCalibrate.path_to_ensemble_member
 ClimaCalibrate.path_to_model_log
 ClimaCalibrate.parameter_path
+ClimaCalibrate.minibatcher_over_samples
+ClimaCalibrate.observation_series_from_samples
 ```

--- a/docs/src/observations.md
+++ b/docs/src/observations.md
@@ -1,0 +1,11 @@
+# Observations
+
+Robust observations and accurate error covariances are essential for successful calibration. When calibrating climate models, it is advisable to use long-term climate statistics, such as monthly or seasonal averages, to reduce the influence of internal variability. This results in a more stable and representative target for inversion.
+
+`EnsembleKalmanProcesses.jl` provides several containers for managing observations, with documentation provided [here](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/observations/).
+As inputs to a calibration, observations can consist of a `Vector`, an `EKP.Observation` (a single observation), or an `EKP.ObservationSeries` (many observations).
+
+To iterate through an `EKP.ObservationSeries`, you must provide a minibatcher. This package provides two helper functions to faciliate the creation of simple batches:
+
+- [`ClimaCalibrate.minibatcher_over_samples`](@ref) takes in samples or (a number of samples) and a batch size and returns a minibatcher which divides the samples into the batch size, dropping remaining samples.
+- [`ClimaCalibrate.observation_series_from_samples`](@ref) takes in a vector of `Observation`s and a batch size and returns an `ObservationSeries` with a minibatcher.

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -339,3 +339,61 @@ function last_completed_iteration(output_dir)
     end
     return last_completed_iter
 end
+
+_fixed_minibatcher_indices(n_batches, batch_size) =
+    [collect(((i - 1) * batch_size + 1):(i * batch_size)) for i in 1:n_batches]
+"""
+    minibatcher_over_samples(n_samples, batch_size)
+
+Create a `FixedMinibatcher` that divides `n_samples` into batches of size `batch_size`.
+
+If `n_samples` is not divisible by `batch_size`, the remaining samples will be dropped.
+"""
+function minibatcher_over_samples(n_samples::Int, batch_size::Int)
+    n_samples <= 0 &&
+        throw(ArgumentError("Number of samples ($n_samples) must be positive"))
+    batch_size <= 0 &&
+        throw(ArgumentError("Batch size ($batch_size) must be positive"))
+    n_batches = div(n_samples, batch_size)
+    remainder = n_samples % batch_size
+    if remainder > 0
+        @warn "Number of samples $n_samples not divisible by batch size $batch_size. The last $(remainder) samples will be dropped."
+    end
+    given_batches = _fixed_minibatcher_indices(n_batches, batch_size)
+    return EKP.FixedMinibatcher(given_batches)
+end
+
+"""
+    minibatcher_over_samples(samples, batch_size)
+
+Create a `FixedMinibatcher` that divides a vector of samples into batches of size `batch_size`.
+
+If the number of samples is not divisible by `batch_size`, the remaining samples will be dropped.
+"""
+function minibatcher_over_samples(samples::Vector, batch_size::Int)
+    return minibatcher_over_samples(length(samples), batch_size)
+end
+
+"""
+    observation_series_from_samples(samples, batch_size, names = nothing)
+
+Create an `EKP.ObservationSeries` from a vector of `EKP.Observation` samples.
+
+If the number of samples is not divisible by `batch_size`, the remaining samples will be dropped.
+"""
+function observation_series_from_samples(
+    samples::Vector{<:EKP.Observation},
+    batch_size,
+    names = nothing,
+)
+    if !isnothing(names) && length(names) != length(samples)
+        throw(
+            ArgumentError(
+                "Number of names ($(length(names))) must match number of samples ($(length(samples)))",
+            ),
+        )
+    end
+    minibatcher = minibatcher_over_samples(samples, batch_size)
+    names = isnothing(names) ? string.(1:length(samples)) : names
+    return EKP.ObservationSeries(samples, minibatcher, names)
+end

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -133,7 +133,8 @@ function Distributed.launch(
     output_path = get(params, :o, get(params, :output, default_output))
 
     ntasks = sm.ntasks
-    srun_cmd = `srun -J $jobname -n $ntasks -D $exehome $worker_args -o $output_path -- $exename $exeflags $(worker_cookie_arg())`
+    srun_cmd =
+        `srun -J $jobname -n $ntasks -D $exehome $worker_args -o $output_path -- $exename $exeflags $(worker_cookie_arg())`
     @info "Starting SLURM job $jobname: $srun_cmd"
     pid = open(addenv(srun_cmd, env))
 
@@ -335,7 +336,8 @@ function Distributed.launch(
         -j oe: Send the output and error streams to the same file
         -J 1-ntasks: Job array
         -o: output file =#
-    qsub_cmd = `qsub -V -N $jobname -j oe $job_array_option $worker_args -o $output_path -- $exename $exeflags $(worker_cookie_arg())`
+    qsub_cmd =
+        `qsub -V -N $jobname -j oe $job_array_option $worker_args -o $output_path -- $exename $exeflags $(worker_cookie_arg())`
     @info "Starting PBS job $jobname: $qsub_cmd"
     pid = open(addenv(qsub_cmd, env))
 

--- a/test/ekp_interface.jl
+++ b/test/ekp_interface.jl
@@ -129,3 +129,55 @@ end
     @test member_number == CAL.env_member_number(test_ENV)
     @test model_interface == CAL.env_model_interface(test_ENV)
 end
+
+@testset "minibatcher_over_samples tests" begin
+    # Regular case
+    mb = CAL.minibatcher_over_samples(6, 2)
+    @test mb.minibatches == [[1, 2], [3, 4], [5, 6]]
+
+    # Non-divisible case: 7 samples with batch size 2 (should drop last sample)
+    mb_partial = CAL.minibatcher_over_samples(7, 2)
+    @test mb_partial.minibatches == [[1, 2], [3, 4], [5, 6]]  # 7th is dropped
+
+    # Edge: batch size larger than n_samples
+    mb_small = CAL.minibatcher_over_samples(3, 5)
+    @test mb_small.minibatches == []
+
+    # Edge: n_samples = 0
+    @test_throws ArgumentError CAL.minibatcher_over_samples(0, 2)
+
+    # Edge: batch_size = 0
+    @test_throws ArgumentError CAL.minibatcher_over_samples(2, 0)
+
+    # Using vector input
+    samples = [1, 2, 3, 4, 5, 6]
+    mb2 = CAL.minibatcher_over_samples(samples, 2)
+    @test mb2.minibatches == [[1, 2], [3, 4], [5, 6]]
+end
+
+@testset "observation_series_from_samples tests" begin
+    samples = [EKP.Observation([i], ones(1, 1), string(i)) for i in 1:6]
+    # Regular case
+    series = CAL.observation_series_from_samples(samples, 2)
+    @test series.observations == samples
+    @test series.minibatcher.minibatches == [[1, 2], [3, 4], [5, 6]]
+    @test series.names == ["1", "2", "3", "4", "5", "6"]
+
+    # fewer samples than batch size
+    series2 = CAL.observation_series_from_samples(samples, 7)
+    @test series2.minibatcher.minibatches == []  # No batches
+
+    # empty sample list
+    @test_throws ArgumentError CAL.observation_series_from_samples(
+        EKP.Observation[],
+        2,
+    )
+
+    # Test mismatched names
+    bad_names = ["a", "b", "c"]
+    @test_throws ArgumentError CAL.observation_series_from_samples(
+        samples,
+        2,
+        bad_names,
+    )
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds functions to help construct minibatches and observation series from vectors of data. Closes #169 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- Add documentation

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- `minibatcher_over_samples(n_samples, batch_size)` takes in a number of samples and a batch size and returns a `FixedMinibatcher`. `minibatcher_over_samples(samples, batch_size)` does the same but takes in the actual samples.
- `observation_series_from_samples(samples, batch_size, names = nothing)` creates an `ObservationSeries` from the samples with the proper minibatcher.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
