### PR TITLE
Add ObservationRecipe.short_names

### DIFF
--- a/ext/ClimaAnalysisExt.jl
+++ b/ext/ClimaAnalysisExt.jl
@@ -305,6 +305,28 @@ function ObservationRecipe.observation(
 end
 
 """
+    short_names(obs::EKP.Observation)
+
+Get the short names of the variables from the metadata in the `EKP.Observation`.
+
+If the short name is not available, then `nothing` is returned instead.
+"""
+function ObservationRecipe.short_names(obs::EKP.Observation)
+    # Get the short names from the metadata rather than the name of the
+    # observation, because the name can be changed by the user
+    metadatas = EKP.get_metadata(obs)
+    eltype(metadatas) <: ClimaAnalysis.Var.Metadata || error(
+        "Getting the short names from an observation is only supported with metadata from ClimaAnalysis",
+    )
+
+    short_names = collect(
+        get(metadata.attributes, "short_name", nothing) for
+        metadata in metadatas
+    )
+    return short_names
+end
+
+"""
     seasonally_aligned_yearly_sample_date_ranges(var::OutputVar)
 
 Generate sample dates that conform to a seasonally aligned year from

--- a/src/observation_recipe.jl
+++ b/src/observation_recipe.jl
@@ -5,6 +5,7 @@ export ScalarCovariance,
     SVDplusDCovariance,
     covariance,
     observation,
+    short_names,
     seasonally_aligned_yearly_sample_date_ranges,
     change_data_type
 
@@ -274,6 +275,8 @@ end
 function covariance end
 
 function observation end
+
+function short_names end
 
 function seasonally_aligned_yearly_sample_date_ranges end
 

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -1066,3 +1066,42 @@ end
     )
 
 end
+
+@testset "Short names of observation" begin
+    if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
+        time =
+            ClimaAnalysis.Utils.date_to_time.(
+                Dates.DateTime(2007, 12),
+                [Dates.DateTime(2007, 12) + Dates.Month(i) for i in 0:2],
+            )
+        var1 =
+            TemplateVar() |>
+            add_dim("time", time, units = "s") |>
+            add_attribs(short_name = "Hello", start_date = "2007-12-1") |>
+            initialize
+
+        var2 =
+            TemplateVar() |>
+            add_dim("time", time, units = "s") |>
+            add_attribs(short_name = "world!", start_date = "2007-12-1") |>
+            initialize
+
+        var3 =
+            TemplateVar() |>
+            add_dim("time", time, units = "s") |>
+            add_attribs(no_short_name = "no", start_date = "2007-12-1") |>
+            initialize
+
+        covar_estimator = ObservationRecipe.ScalarCovariance()
+        obs = ObservationRecipe.observation(
+            covar_estimator,
+            (var1, var2, var3),
+            Dates.DateTime(2007, 12, 1),
+            Dates.DateTime(2008, 1, 1),
+        )
+        @test isequal(
+            ObservationRecipe.short_names(obs),
+            ["Hello", "world!", nothing],
+        )
+    end
+end


### PR DESCRIPTION
This commit adds `ObservationRecipe.short_names` which get the short names of the variables in the observation.

TODO list

- [x]  > EnsembleKalmanProcesses v2.4.2
- [x] Write tests for this function