### PR TITLE
Add function to reconstruct diagonal of covariance matrix as a OutputVar

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -83,6 +83,7 @@ ClimaCalibrate.ObservationRecipe.observation
 ClimaCalibrate.ObservationRecipe.short_names
 ClimaCalibrate.ObservationRecipe.get_metadata_for_nth_iteration
 ClimaCalibrate.ObservationRecipe.reconstruct_g_mean_final
+ClimaCalibrate.ObservationRecipe.reconstruct_diag_cov
 ClimaCalibrate.ObservationRecipe.seasonally_aligned_yearly_sample_date_ranges
 ClimaCalibrate.ObservationRecipe.change_data_type
 ```

--- a/src/observation_recipe.jl
+++ b/src/observation_recipe.jl
@@ -286,6 +286,8 @@ function change_data_type end
 
 function reconstruct_g_mean_final end
 
+function reconstruct_diag_cov end
+
 function get_metadata_for_nth_iteration end
 
 end


### PR DESCRIPTION
closes #231 - This PR adds `ObservationRecipe.reconstruct_diag_cov` which allows one to reconstruct the diagonal of covariance matrix as a `OutputVar`.

TODOs
- [x] Add tests