### PR TITLE
Fix bug with SignChecker when NaNs are present

### DIFF
--- a/ext/checkers.jl
+++ b/ext/checkers.jl
@@ -264,7 +264,8 @@ function Checker.check(
     # This is inaccurate, because not all the values in var.data will end up in
     # the G ensemble matrix. See _match_dates for one case. However, the mean
     # should not change that much with additional times.
-    sim_pos_proportion = nanmean(var.data .> 0)
+    valid = @. !isnan(var.data)
+    sim_pos_proportion = sum(valid .& (var.data .> 0)) / sum(valid)
 
     same_sign = abs(obs_pos_proportion - sim_pos_proportion) < checker.threshold
     !same_sign &&

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -204,6 +204,17 @@ import ClimaAnalysis.Template:
         data = make_flat_data(neg_var),
     )
 
+    # Check case with NaN
+    nan_data = collect(Float64.(copy(var.data)))
+    nan_data[1] = NaN
+    nan_var = ClimaAnalysis.remake(var, data = nan_data)
+    @test Checker.check(
+        sign_checker,
+        nan_var,
+        make_metadata(var),
+        data = make_flat_data(var),
+    )
+
     @test_logs (:info, r"Proportion of positive values in the simulation data ") Checker.check(
         sign_checker,
         var,


### PR DESCRIPTION
The original code is `nanmean(var.data .> 0)`. This does not work, because `NaN > 0` is `false` and not `NaN`.

closes #254