### PR TITLE
Warn on a single time value in seq indices checker

### DIFF
--- a/ext/checkers.jl
+++ b/ext/checkers.jl
@@ -227,6 +227,10 @@ function Checker.check(
     sim_dates = ClimaAnalysis.dates(var)
     sim_indices_for_obs_dates = indexin(obs_dates, sim_dates)
 
+    length(sim_indices_for_obs_dates) == 1 && @warn(
+        "There is only one date in the metadata. SequentialIndicesChecker will always return true"
+    )
+
     # Do not need to check for nothing in sim_indices_for_obs_dates because
     # of DimValuesChecker
     for i in eachindex(sim_indices_for_obs_dates)[2:end]

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -187,6 +187,18 @@ import ClimaAnalysis.Template:
         verbose = true,
     )
 
+    # Check warning from SequentialIndicesChecker
+    date_var5 =
+        TemplateVar() |>
+        add_dim("time", [0.0], units = "s") |>
+        add_attribs(start_date = "2010-12-01T00:00:42") |>
+        initialize
+    @test_logs (:warn, r"only one date in the metadata") Checker.check(
+        sequential_indices_checker,
+        date_var5,
+        make_metadata(date_var5),
+    )
+
     # Check sign of data
     sign_checker = Checker.SignChecker(0.05)
     neg_var = ClimaAnalysis.remake(var, data = -var.data)


### PR DESCRIPTION
closes #255 - This PR adds a warning when there is a single time value in the metadata/observational data when using `SequentialIndicesChecker`.