### PR TITLE
Update ClimaGPUBackend modules

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -174,7 +174,7 @@ end
 
 function module_load_string(::ClimaGPUBackend)
     return """module purge
-    module load julia/1.11.0 cuda/julia-pref openmpi/4.1.5-mpitrampoline"""
+    module load climacommon/2025_05_15"""
 end
 
 function module_load_string(::DerechoBackend)


### PR DESCRIPTION
This PR updates the `module_load_str(::ClimaGPUBackend)` method to return `climacommon/2025_05_15` and use julia/1.11.5 on clima.