### PR TITLE
Add rank keyword argument for SVDplusDCovariance

### DIFF
--- a/ext/observation_recipe.jl
+++ b/ext/observation_recipe.jl
@@ -213,7 +213,17 @@ function ObservationRecipe.covariance(
         min_cosd_lat = covar_estimator.min_cosd_lat,
     )
 
-    gamma_low_rank = EKP.tsvd_cov_from_samples(stacked_sample_matrix)
+    (; rank) = covar_estimator
+    gamma_low_rank = if isnothing(rank)
+        EKP.tsvd_cov_from_samples(stacked_sample_matrix)
+    else
+        EKP.tsvd_cov_from_samples(stacked_sample_matrix, rank)
+    end
+
+    rank_of_svd = length(gamma_low_rank.S)
+    !isnothing(rank) &&
+        rank_of_svd != rank &&
+        @warn "Rank of SVD is $rank_of_svd but requested rank is $rank"
 
     # Add model error scale. This may not make sense if the samples do not
     # represent a single year. For example, if the stacked samples are seasonal

--- a/src/observation_recipe.jl
+++ b/src/observation_recipe.jl
@@ -202,6 +202,7 @@ struct SVDplusDCovariance{
     FT2 <: AbstractFloat,
     DATE <: Dates.AbstractDateTime,
     FT3 <: AbstractFloat,
+    R <: Union{Integer, Nothing},
 } <: AbstractCovarianceEstimator
     """A model error scale term added to the diagonal of the covariance
     matrix"""
@@ -218,6 +219,9 @@ struct SVDplusDCovariance{
 
     """The minimum cosine weight when using latitude weighting"""
     min_cosd_lat::FT3
+
+    """Rank of the singular value decomposition (SVD)"""
+    rank::R
 end
 
 """
@@ -225,7 +229,8 @@ end
                        model_error_scale = 0.0,
                        regularization = 0.0,
                        use_latitude_weights = false,
-                       min_cosd_lat = 0.1)
+                       min_cosd_lat = 0.1,
+                       rank = nothing)
 
 Create a `SVDplusDCovariance` which specifies how the covariance matrix should
 be formed. When used with `ObservationRecipe.observation` or
@@ -270,6 +275,9 @@ Keyword arguments
   `use_latitude_weights` is `true`. The value for `min_cosd_lat` must be greater
   than zero as values close to zero along the diagonal of the covariance matrix
   can lead to issues when taking the inverse of the covariance matrix.
+
+- `rank`: Rank of the singlar value decomposition (SVD). If `nothing` is passed
+  in, then the rank is automatically inferred from the data.
 """
 function SVDplusDCovariance(
     sample_date_ranges;
@@ -277,6 +285,7 @@ function SVDplusDCovariance(
     regularization = 0.0,
     use_latitude_weights = false,
     min_cosd_lat = 0.1,
+    rank = nothing,
 )
     model_error_scale < zero(model_error_scale) &&
         error("Model_error_scale ($model_error_scale) should not be negative")
@@ -296,12 +305,17 @@ function SVDplusDCovariance(
             "The value for min_cosd_lat ($min_cosd_lat) should be greater than zero",
         )
     end
+    isnothing(rank) ||
+        rank >= 0 ||
+        error("Rank ($rank) should be nothing or non-negative")
+
     return SVDplusDCovariance(
         model_error_scale,
         regularization,
         sample_date_ranges,
         use_latitude_weights,
         min_cosd_lat,
+        rank,
     )
 end
 

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -778,6 +778,27 @@ end
         ),
     )
 
+    # Test rank
+    covar_estimator_rank0 =
+        ObservationRecipe.SVDplusDCovariance(sample_date_ranges; rank = 0)
+    svd_plus_d_covar_rank0 = ObservationRecipe.covariance(
+        covar_estimator_rank0,
+        var,
+        Dates.DateTime(2007, 12),
+        Dates.DateTime(2008, 9),
+    )
+    # It is silly to use a rank of 0 for SVD, but it simplifies testing
+    # There are no eigenvalues for a rank 0 SVD
+    @test isempty(svd_plus_d_covar_rank0.svd_cov.S)
+
+    covar_estimator_rank10 =
+        ObservationRecipe.SVDplusDCovariance(sample_date_ranges; rank = 10)
+    @test_logs (:warn, r"rank") ObservationRecipe.covariance(
+        covar_estimator_rank10,
+        var,
+        Dates.DateTime(2007, 12),
+        Dates.DateTime(2008, 9),
+    )
 
     # Test float type
     covar_estimator = ObservationRecipe.SVDplusDCovariance(
@@ -848,6 +869,11 @@ end
         var,
         Dates.DateTime(2007, 12),
         Dates.DateTime(2008, 3),
+    )
+
+    @test_throws ErrorException ObservationRecipe.SVDplusDCovariance(
+        sample_date_ranges;
+        rank = -1,
     )
 end
 


### PR DESCRIPTION
This PR adds the `rank` keyword argument for `SVDplusDCovariance`. This allows for finer control over the rank of the covariance matrix rather than depending on what `EKP` chooses for the rank.