### PR TITLE
Add SVD residual analysis utilities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaCalibrate.jl Release Notes
 main
 -------
 
+- Add noise covariance and residual analysis tools [#286](https://github.com/CliMA/ClimaCalibrate.jl/pull/286)
+
+v0.2.2
+-------
+- Add quantile regularization to the SVDPlusDCovariance [#277](https://github.com/CliMA/ClimaCalibrate.jl/pull/277)
+
 v0.2.0
 -------
-- Refactor backend structs to store relevant information [245](https://github.com/CliMA/ClimaCalibrate.jl/pull/245)
+- Refactor backend structs to store relevant information [#245](https://github.com/CliMA/ClimaCalibrate.jl/pull/245)

--- a/Project.toml
+++ b/Project.toml
@@ -4,29 +4,32 @@ authors = ["Climate Modeling Alliance"]
 version = "0.2.2"
 
 [deps]
+ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
 CalibrateEmulateSample = "95e48a1f-0bec-4818-9538-3db4340308e3"
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNStatistics = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extensions]
 CESExt = "CalibrateEmulateSample"
-ClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics", "Statistics", "LinearAlgebra"]
+ClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
 
 [compat]
 Aqua = "0.8"
+ArnoldiMethod = "0.4.0"
 CalibrateEmulateSample = "0.5, 0.6, 0.7"
 ClimaAnalysis = "0.5.20"
 ClimaParams = "0.10, 0.11, 0.12, 1"
@@ -37,6 +40,7 @@ Distributions = "0.25"
 EnsembleKalmanProcesses = "2.5"
 JLD2 = "0.4, 0.5, 0.6"
 LinearAlgebra = "1"
+LinearMaps = "3.11.4"
 Logging = "1.10, 1.11"
 NaNStatistics = "0.6.8 - 0.6.50, 0.6.53"
 OrderedCollections = "1.3"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,6 +93,15 @@ ClimaCalibrate.ObservationRecipe.seasonally_aligned_yearly_sample_date_ranges
 ClimaCalibrate.ObservationRecipe.change_data_type
 ```
 
+## SVD Residual Analysis
+
+```@docs
+ClimaCalibrate.analyze_residual
+ClimaCalibrate.compute_structured_energy
+ClimaCalibrate.compute_structured_energy_by_variable
+ClimaCalibrate.compute_normalized_projections
+```
+
 ## Ensemble Builder Interface
 
 ```@docs

--- a/src/ClimaCalibrate.jl
+++ b/src/ClimaCalibrate.jl
@@ -14,5 +14,6 @@ include("emulate_sample.jl")
 include("observation_recipe.jl")
 include("ensemble_builder.jl")
 include("checkers.jl")
+include("svd_analysis.jl")
 
 end # module ClimaCalibrate

--- a/src/observation_recipe.jl
+++ b/src/observation_recipe.jl
@@ -375,4 +375,6 @@ function get_observations_for_nth_iteration end
 
 function get_metadata_for_nth_iteration end
 
+function _get_minibatch_indices_for_nth_iteration end
+
 end

--- a/src/svd_analysis.jl
+++ b/src/svd_analysis.jl
@@ -1,0 +1,219 @@
+import LinearAlgebra: SVD, Diagonal, norm, dot, UniformScaling
+import LinearMaps: LinearMap
+import ArnoldiMethod: partialschur, partialeigen
+import Statistics: mean
+
+export compute_structured_energy,
+    compute_structured_energy_by_variable,
+    compute_normalized_projections,
+    analyze_residual
+
+# TODO: Use the function in EKP once it's moved there
+"""
+    _create_compact_linear_map(A)
+
+Wrap an SVD-structured covariance matrix (or a vector of them) as a `LinearMap`
+for use with matrix-free eigensolvers such as `ArnoldiMethod.partialschur`.
+
+Supports `LinearAlgebra.SVD`, `LinearAlgebra.Diagonal`, and `EKP.SVDplusD`
+inputs. If `A` is a vector, the matrices are treated as block-diagonal.
+"""
+function _create_compact_linear_map(A)
+    Avec = isa(A, AbstractVector) ? A : [A]
+
+    Us = []
+    Ss = []
+    VTs = []
+    ds = []
+    batches = []
+    shift = 0
+    for a in Avec
+        if isa(a, UniformScaling)
+            throw(
+                ArgumentError(
+                    "Detected `UniformScaling` (i.e. \"λI\") StructureMatrix, and unable to infer dimensionality. \n Please recast this as a diagonal matrix, defining \"λI(d)\" for dimension d",
+                ),
+            )
+        elseif isa(a, SVD)
+            push!(Us, a.U)
+            push!(Ss, a.S)
+            push!(VTs, a.Vt)
+            push!(ds, zeros(size(a.U, 1)))
+            bsize = size(a.U, 1)
+        elseif isa(a, Diagonal)
+            # No low-rank component; represent as empty U, S, Vt so the
+            # LinearMap formula U*(S.*(Vt*x)) + d.*x reduces to just d.*x
+            n = length(a.diag)
+            push!(Us, zeros(n, 0))
+            push!(Ss, zeros(0))
+            push!(VTs, zeros(0, n))
+            push!(ds, a.diag)
+            bsize = n
+        elseif isa(a, EKP.SVDplusD)
+            svda = a.svd_cov
+            diaga = (a.diag_cov).diag
+            push!(Us, svda.U)
+            push!(Ss, svda.S)
+            push!(VTs, svda.Vt)
+            push!(ds, diaga)
+            bsize = length(diaga)
+        else
+            throw(
+                ArgumentError(
+                    "Unsupported matrix type: $(typeof(a)). Expected SVD, Diagonal, or EKP.SVDplusD.",
+                ),
+            )
+        end
+
+        batch = (shift + 1):(shift + bsize)
+        push!(batches, batch)
+        shift = batch[end]
+    end
+
+    Amap = LinearMap(
+        x -> reduce(
+            vcat,
+            [
+                U * (S .* (Vt * x[batch])) + d .* x[batch] for
+                (U, S, Vt, d, batch) in zip(Us, Ss, VTs, ds, batches)
+            ],
+        ),
+        x -> reduce(
+            vcat,
+            [
+                Vt' * (S .* (U' * x[batch])) + d .* x[batch] for
+                (U, S, Vt, d, batch) in zip(Us, Ss, VTs, ds, batches)
+            ],
+        ),
+        sum(size(U, 1) for U in Us),
+        sum(size(Vt, 2) for Vt in VTs),
+    )
+
+    return Amap
+end
+
+"""
+    compute_structured_energy(projections)
+
+Given the matrix of normalized projections from `compute_normalized_projections`,
+compute the total structured energy in the whitened space:
+
+    energy = (1/n_eig) * ∑ᵢ zᵢ²,   where zᵢ = ∑ᵥ projections[i, v] = aᵢ / √λᵢ
+
+`zᵢ` is the global whitened projection onto eigenvector `i`. Under the noise
+model, `zᵢ ~ N(0, 1)`, so `energy ≈ 1` is consistent with noise. Values >> 1
+indicate mismatch beyond what the structured noise explains. Values << 1
+suggest overfitting to noise or an overestimated noise covariance.
+"""
+function compute_structured_energy(projections)
+    z = sum(projections, dims = 2)
+    return sum(z .^ 2) / length(z)
+end
+
+"""
+    compute_structured_energy_by_variable(projections)
+
+Given the matrix of normalized projections from `compute_normalized_projections`,
+compute the per-variable structured energy in the whitened space:
+
+    energy_v = (1/n_eig) * ∑ᵢ projections[i, v]²
+
+Returns a vector of length `n_variables`. Values >> 1 for variable `v` indicate
+that variable's contribution to the eigenvector projections exceeds noise-model
+predictions. Values ≈ 1 are consistent with noise, and values << 1 suggest
+overfitting or an overestimated noise covariance for that variable.
+
+See also [`analyze_residual`](@ref).
+"""
+function compute_structured_energy_by_variable(projections)
+    n_eig = size(projections, 1)
+    return [sum(projections[:, v] .^ 2) / n_eig for v in axes(projections, 2)]
+end
+
+"""
+    compute_normalized_projections(diff, eigvectors, eigvalues, ranges)
+
+For each eigenvector `i` and variable `v`, compute the variable-specific
+contribution to the normalized projection `aᵢᵛ / √λᵢ`, where
+`aᵢᵛ = vᵢ[rᵥ]ᵀ diff[rᵥ]`.
+
+This is a z-score: values >> 1 indicate model-data mismatch beyond noise;
+values ≤ 1 are consistent with structured noise.
+
+Returns a `Matrix` of shape `(n_eigenvectors, n_variables)`. `ranges` is a
+vector of index ranges, one per variable, giving the observation indices for
+that variable. Pass the result to `compute_structured_energy` or
+`compute_structured_energy_by_variable` for scalar summaries.
+
+See also [`analyze_residual`](@ref).
+"""
+function compute_normalized_projections(diff, eigvectors, eigvalues, ranges)
+    n_eigenvectors = size(eigvectors, 2)
+    n_variables = length(ranges)
+    projections = zeros(n_eigenvectors, n_variables)
+    for (v, r_v) in enumerate(ranges)
+        for i in 1:n_eigenvectors
+            # aᵢᵛ: variable v's contribution to projection onto eigenvector i
+            a_i_v = dot(eigvectors[r_v, i], diff[r_v])
+            projections[i, v] = a_i_v / sqrt(eigvalues[i])
+        end
+    end
+    return projections
+end
+
+"""
+    analyze_residual(ekp, iter; n_eigenvectors = 3)
+
+Analyze the model-data residual (y - G(u)) at iteration `iter` of an EKP calibration
+using the top eigenvectors of the noise covariance.
+
+The noise covariance is obtained via `EKP.get_obs_noise_cov` with `build = false`,
+so it works with any `StructuredMatrix` type supported by EKP (`SVD`, `Diagonal`,
+`SVDplusD`), not only `SVDplusD`.
+
+Returns a named tuple with:
+- `normalized_projections`: `(n_eigenvectors × n_variables)` matrix of z-scores
+  per variable (values >> 1 indicate mismatch beyond noise)
+- `structured_energy`: normalized whitened energy across all variables (≈ 1 under noise model)
+- `structured_energy_by_variable`: per-variable whitened energy
+- `residual_norm_by_variable`: `norm(diff[rᵥ])` for each variable
+- `metadata`: vector of `ClimaAnalysis.Var.Metadata` for each variable, in the
+  same order as the columns of `normalized_projections` and elements of
+  `structured_energy_by_variable` and `residual_norm_by_variable`
+
+Requires ClimaAnalysis to be loaded.
+"""
+function analyze_residual(ekp, iter; n_eigenvectors = 3)
+    obs_series = EKP.get_observation_series(ekp)
+    obs_noise_cov = EKP.get_obs_noise_cov(obs_series; build = false)
+    linear_map = _create_compact_linear_map(obs_noise_cov)
+    result, _ = partialschur(linear_map; nev = n_eigenvectors)
+    eigvalues, eigvectors = partialeigen(result)
+
+    # Reverse so index 1 = dominant eigenvector
+    reverse!(eigvalues)
+    reverse!(eigvectors, dims = 2)
+
+    g = EKP.get_g(ekp, iter)
+    succ_ens, _ = EKP.split_indices_by_success(g)
+    mean_g = dropdims(mean(g[:, succ_ens], dims = 2), dims = 2)
+    diff = EKP.get_obs(ekp, iter) - mean_g
+
+    metadata =
+        ObservationRecipe.get_metadata_for_nth_iteration(obs_series, iter)
+    ranges = ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+        obs_series,
+        iter,
+    )
+    projections =
+        compute_normalized_projections(diff, eigvectors, eigvalues, ranges)
+    return (;
+        normalized_projections = projections,
+        structured_energy = compute_structured_energy(projections),
+        structured_energy_by_variable = compute_structured_energy_by_variable(
+            projections,
+        ),
+        residual_norm_by_variable = map(r -> norm(diff[r]), ranges),
+        metadata,
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using SafeTestsets
 @safetestset "Aqua" begin include("aqua.jl") end
 @safetestset "Observation recipe" begin include("observation_recipe.jl") end
 @safetestset "Ensemble builder" begin include("ensemble_builder.jl") end
+@safetestset "SVD analysis" begin include("svd_analysis.jl") end
 #! format: on
 
 nothing

--- a/test/svd_analysis.jl
+++ b/test/svd_analysis.jl
@@ -1,0 +1,135 @@
+using Test
+using LinearAlgebra
+import EnsembleKalmanProcesses as EKP
+import ClimaCalibrate as CAL
+using LinearMaps
+
+@testset "create_compact_linear_map" begin
+    @testset "SVD input" begin
+        # Use a square symmetric matrix
+        A = randn(8, 6)
+        cov_A = A * A'  # 8×8 symmetric PSD
+        svd_A = svd(cov_A)
+        lmap = CAL._create_compact_linear_map(svd_A)
+        @test lmap isa LinearMap
+        @test size(lmap) == (8, 8)
+        x = randn(8)
+        expected = svd_A.U * (svd_A.S .* (svd_A.Vt * x))
+        @test lmap * x ≈ expected
+    end
+
+    @testset "Diagonal input" begin
+        d = rand(6) .+ 0.1
+        diag_mat = Diagonal(d)
+        lmap = CAL._create_compact_linear_map(diag_mat)
+        @test lmap isa LinearMap
+        @test size(lmap) == (6, 6)
+        x = randn(6)
+        @test lmap * x ≈ d .* x
+    end
+
+    @testset "EKP.SVDplusD input" begin
+        samples = randn(8, 20)
+        svd_cov = EKP.tsvd_cov_from_samples(samples)
+        d = 0.01 * ones(8)
+        svdplusd = EKP.SVDplusD(svd_cov, Diagonal(d))
+        lmap = CAL._create_compact_linear_map(svdplusd)
+        @test lmap isa LinearMap
+        @test size(lmap) == (8, 8)
+        # Spot-check: applying Γ = U*S*Vt + D to a vector
+        x = randn(8)
+        svda = svdplusd.svd_cov
+        diaga = svdplusd.diag_cov.diag
+        expected = svda.U * (svda.S .* (svda.Vt * x)) + diaga .* x
+        @test lmap * x ≈ expected
+    end
+
+    @testset "UniformScaling throws" begin
+        @test_throws ArgumentError CAL._create_compact_linear_map(I)
+    end
+
+    @testset "Unsupported type throws" begin
+        @test_throws ArgumentError CAL._create_compact_linear_map(randn(5, 5))
+    end
+
+    @testset "Vector of SVDs (block-diagonal)" begin
+        A1 = randn(5, 3)
+        cov1 = A1 * A1'
+        A2 = randn(4, 2)
+        cov2 = A2 * A2'
+        lmap = CAL._create_compact_linear_map([svd(cov1), svd(cov2)])
+        @test size(lmap) == (9, 9)
+        # Each block acts independently
+        x = randn(9)
+        s1, s2 = svd(cov1), svd(cov2)
+        expected = vcat(
+            s1.U * (s1.S .* (s1.Vt * x[1:5])),
+            s2.U * (s2.S .* (s2.Vt * x[6:9])),
+        )
+        @test lmap * x ≈ expected
+    end
+end
+
+@testset "compute_structured_energy" begin
+    @testset "zero projections → zero energy" begin
+        @test CAL.compute_structured_energy(zeros(3, 2)) == 0.0
+    end
+
+    @testset "consistent with manual calculation" begin
+        proj = [1.0 2.0; 3.0 4.0; 5.0 6.0]  # 3 eigvecs × 2 vars
+        z = vec(sum(proj, dims = 2))           # [3.0, 7.0, 11.0]
+        @test CAL.compute_structured_energy(proj) ≈ sum(z .^ 2) / length(z)
+    end
+
+    @testset "unit noise → energy ≈ 1 in expectation" begin
+        # z[i] = sum_v(proj[i,v]); if proj[i,v] ~ N(0,1) with many draws,
+        # energy = sum(z^2)/n_eig concentrates around n_vars
+        proj = ones(5, 1)  # z[i] = 1 for all i → energy = 1
+        @test CAL.compute_structured_energy(proj) ≈ 1.0
+    end
+end
+
+@testset "compute_structured_energy_by_variable" begin
+    @testset "returns one value per variable" begin
+        proj = randn(3, 4)
+        @test length(CAL.compute_structured_energy_by_variable(proj)) == 4
+    end
+
+    @testset "consistent with manual calculation" begin
+        proj = [1.0 2.0; 3.0 4.0; 5.0 6.0]  # 3 eigvecs × 2 vars
+        result = CAL.compute_structured_energy_by_variable(proj)
+        @test result[1] ≈ (1^2 + 3^2 + 5^2) / 3
+        @test result[2] ≈ (2^2 + 4^2 + 6^2) / 3
+    end
+
+    @testset "consistent with global energy when one variable" begin
+        proj = randn(4, 1)
+        @test only(CAL.compute_structured_energy_by_variable(proj)) ≈
+              CAL.compute_structured_energy(proj)
+    end
+end
+
+@testset "compute_normalized_projections" begin
+    n_obs, n_eig = 10, 3
+    Q, _ = qr(randn(n_obs, n_obs))
+    eigvecs = Matrix(Q)[:, 1:n_eig]
+    eigvalues = [4.0, 2.0, 1.0]
+    diff = randn(n_obs)
+
+    # Mock metadata_vec using named tuples — only the `range` field is accessed
+    metadata_vec = [(range = 1:6,), (range = 7:10,)]
+    proj = CAL.compute_normalized_projections(
+        diff,
+        eigvecs,
+        eigvalues,
+        metadata_vec,
+    )
+
+    @test size(proj) == (n_eig, 2)
+
+    # Compare against manual calculation
+    @test proj[1, 1] ≈ dot(eigvecs[1:6, 1], diff[1:6]) / sqrt(4.0)
+    @test proj[2, 1] ≈ dot(eigvecs[1:6, 2], diff[1:6]) / sqrt(2.0)
+    @test proj[1, 2] ≈ dot(eigvecs[7:10, 1], diff[7:10]) / sqrt(4.0)
+    @test proj[3, 2] ≈ dot(eigvecs[7:10, 3], diff[7:10]) / sqrt(1.0)
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This PR adds tools to analyze model-data mismatch when using SVDPlusD noise covariances.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

- `compute_structured_energy(diff, eigvectors)` scalar ratio of the residual's norm in the top-eigenvector subspace to the unstructured remainder. Values > 1 mean structured noise dominates.
- `compute_structured_energy_by_variable(diff, eigvectors, metadata_vec)` same ratio computed per variable
- `compute_normalized_projections(diff, eigvectors, eigvalues, metadata_vec)` returns a (n_eigenvectors x n_variables) matrix of z-scores `a_i / sqrt(lambda_i)`. Values >> 1 indicate mismatch beyond noise for that variable/eigenvector pair.
- `analyze_residual(ekp, iter; n_eigenvectors=3)` orchestrates the above, returning all four diagnostics (normalized_projections, structured_energy, structured_energy_by_variable, residual_norm_by_variable).
- Added ArnoldiMethod, LinearMaps as dependencies. These are small packages which don't introduce any large deps.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
