### PR TITLE
Fix bugs in analyze_residual

### DIFF
--- a/ext/ensemble_builder.jl
+++ b/ext/ensemble_builder.jl
@@ -89,7 +89,11 @@ function EnsembleBuilder.GEnsembleBuilder(
     completed = falses(length(metadatas), EKP.get_N_ens(ekp))
 
     short_name_to_metadata_map = Dict{String, Vector{MetadataInfo}}()
-    minibatch_indices = _get_minibatch_indices_for_nth_iteration(obs_series, N)
+    minibatch_indices =
+        ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+            obs_series,
+            N,
+        )
 
     # Assume G_ens and minibatch_indices are one-indexed
     @assert first(size(G_ens)) == last(last(minibatch_indices))

--- a/ext/observation_recipe.jl
+++ b/ext/observation_recipe.jl
@@ -705,10 +705,11 @@ function ObservationRecipe.reconstruct_g_mean_final(
     )
 
     # Reconstruct each OutputVar from the metadata
-    minibatch_indices = _get_minibatch_indices_for_nth_iteration(
-        obs_series,
-        EKP.get_N_iterations(ekp),
-    )
+    minibatch_indices =
+        ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+            obs_series,
+            EKP.get_N_iterations(ekp),
+        )
     vars = map(metadatas, minibatch_indices) do metadata, range
         ClimaAnalysis.unflatten(metadata, g_mean[range])
     end
@@ -774,7 +775,10 @@ Note that the `indices` field in the `EKP.observation` cannot be used as the
 multiple `OutputVar`s are flattened and concatenated together as a single
 vector.
 """
-function _get_minibatch_indices_for_nth_iteration(obs_series, N)
+function ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+    obs_series,
+    N,
+)
     all_metadata = ClimaCalibrate.get_metadata_for_nth_iteration(obs_series, N)
     minibatch_indices = _get_indices_of_metadata(all_metadata)
     return minibatch_indices

--- a/src/svd_analysis.jl
+++ b/src/svd_analysis.jl
@@ -185,7 +185,8 @@ Requires ClimaAnalysis to be loaded.
 """
 function analyze_residual(ekp, iter; n_eigenvectors = 3)
     obs_series = EKP.get_observation_series(ekp)
-    obs_noise_cov = EKP.get_obs_noise_cov(obs_series; build = false)
+    N_iters = EKP.get_N_iterations(ekp)
+    obs_noise_cov = EKP.get_obs_noise_cov(obs_series, N_iters; build = false)
     linear_map = _create_compact_linear_map(obs_noise_cov)
     result, _ = partialschur(linear_map; nev = n_eigenvectors)
     eigvalues, eigvectors = partialeigen(result)
@@ -199,8 +200,7 @@ function analyze_residual(ekp, iter; n_eigenvectors = 3)
     mean_g = dropdims(mean(g[:, succ_ens], dims = 2), dims = 2)
     diff = EKP.get_obs(ekp, iter) - mean_g
 
-    metadata =
-        ObservationRecipe.get_metadata_for_nth_iteration(obs_series, iter)
+    metadata = EKPUtils.get_metadata_for_nth_iteration(obs_series, iter)
     ranges = ObservationRecipe._get_minibatch_indices_for_nth_iteration(
         obs_series,
         iter,

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -1465,11 +1465,20 @@ end
     metadata2 = ClimaCalibrate.get_metadata_for_nth_iteration(obs_series, 2)
     metadata3 = ClimaCalibrate.get_metadata_for_nth_iteration(obs_series, 3)
     metadata_indices1 =
-        ext._get_minibatch_indices_for_nth_iteration(obs_series, 1)
+        ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+            obs_series,
+            1,
+        )
     metadata_indices2 =
-        ext._get_minibatch_indices_for_nth_iteration(obs_series, 2)
+        ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+            obs_series,
+            2,
+        )
     metadata_indices3 =
-        ext._get_minibatch_indices_for_nth_iteration(obs_series, 3)
+        ObservationRecipe._get_minibatch_indices_for_nth_iteration(
+            obs_series,
+            3,
+        )
     obs1 = ClimaCalibrate.get_observations_for_nth_iteration(obs_series, 1)
     obs2 = ClimaCalibrate.get_observations_for_nth_iteration(obs_series, 2)
     obs3 = ClimaCalibrate.get_observations_for_nth_iteration(obs_series, 3)

--- a/test/svd_analysis.jl
+++ b/test/svd_analysis.jl
@@ -1,8 +1,24 @@
 using Test
+import Dates
 using LinearAlgebra
-import EnsembleKalmanProcesses as EKP
-import ClimaCalibrate as CAL
 using LinearMaps
+import EnsembleKalmanProcesses as EKP
+import EnsembleKalmanProcesses.ParameterDistributions
+import ClimaCalibrate as CAL
+import ClimaCalibrate.ObservationRecipe
+import ClimaCalibrate.EnsembleBuilder
+import ClimaAnalysis
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_time_dim,
+    add_lon_dim,
+    add_lat_dim,
+    add_data,
+    one_to_n_data,
+    initialize
 
 @testset "create_compact_linear_map" begin
     @testset "SVD input" begin
@@ -132,4 +148,93 @@ end
     @test proj[2, 1] ≈ dot(eigvecs[1:6, 2], diff[1:6]) / sqrt(2.0)
     @test proj[1, 2] ≈ dot(eigvecs[7:10, 1], diff[7:10]) / sqrt(4.0)
     @test proj[3, 2] ≈ dot(eigvecs[7:10, 3], diff[7:10]) / sqrt(1.0)
+end
+
+@testset "analyze_residual" begin
+    # The correctness of each of the function called in analyze_residual was
+    # checked in the earlier tests, so this test checks that the function works
+    # on an EKP object
+    lat = [-90.0, -30.0, 30.0, 90.0]
+    lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    time =
+        ClimaAnalysis.Utils.date_to_time.(
+            Dates.DateTime(2007, 12),
+            [Dates.DateTime(2007, 12) + Dates.Month(i) for i in 0:35],
+        )
+    var =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+        ) |>
+        one_to_n_data(collected = true) |>
+        initialize
+    var = ClimaAnalysis.average_season_across_time(var)
+    no_lon_var = ClimaAnalysis.average_lon(var)
+    ClimaAnalysis.set_short_name!(no_lon_var, "no_lon")
+
+    sample_date_ranges = [
+        (Dates.DateTime(i, 12, 1), Dates.DateTime(i + 1, 9, 1)) for
+        i in 2007:2009
+    ]
+
+    covar_estimator_with_q_reg = ObservationRecipe.SVDplusDCovariance(
+        sample_date_ranges;
+        regularization = 0.01,
+        model_error_scale = 0.05,
+    )
+
+    obs_vec = [
+        ObservationRecipe.observation(
+            covar_estimator_with_q_reg,
+            (var,),
+            "2007-12-1",
+            "2008-9-1",
+        ),
+        ObservationRecipe.observation(
+            covar_estimator_with_q_reg,
+            (no_lon_var,),
+            "2007-12-1",
+            "2008-9-1",
+        ),
+    ]
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => obs_vec,
+            "minibatcher" =>
+                CAL.minibatcher_over_samples(length(obs_vec), 1),
+        ),
+    )
+    prior = ParameterDistributions.constrained_gaussian(
+        "pi_groups_coeff",
+        1.0,
+        0.3,
+        0,
+        Inf,
+    )
+    eki = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+    g_ens_builder = EnsembleBuilder.GEnsembleBuilder(eki)
+    EnsembleBuilder.fill_g_ens_col!.(Ref(g_ens_builder), 1:3, Ref(var))
+    EnsembleBuilder.fill_g_ens_col!.(Ref(g_ens_builder), 1:3, Ref(no_lon_var))
+    g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    EKP.update_ensemble!(eki, g_ens)
+
+    n_eigenvectors = 3
+    analysis = CAL.analyze_residual(eki, 1; n_eigenvectors)
+
+    num_vars = 1
+    @test eltype(analysis.metadata) <: ClimaAnalysis.Var.Metadata
+    @test size(analysis.normalized_projections) == (n_eigenvectors, num_vars)
+    @test length(analysis.residual_norm_by_variable) == num_vars
+    @test length(analysis.structured_energy) == 1
+    @test length(analysis.structured_energy_by_variable) == num_vars
 end


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCalibrate.jl/issues/300

The first bug was that `get_metadata_for_nth_iteration` was being qualified with `ObservationRecipe` instead of `EKPUtils`. This was not caught because the function was never exercised in the test suite. The second bug was an indexing issue when retrieving the covariance matrix with `get_obs_noise_cov`.