### PR TITLE
Set random seed for WorkerBackend calibration

### DIFF
--- a/test/worker_backend.jl
+++ b/test/worker_backend.jl
@@ -1,5 +1,6 @@
 import ClimaCalibrate
 using Distributed
+import Random
 import EnsembleKalmanProcesses as EKP
 
 include(
@@ -63,12 +64,16 @@ end
     ),
 )
 
+rng_seed = 1234
+Random.seed!(rng_seed)
+rng_ekp = Random.MersenneTwister(rng_seed)
 user_initial_ensemble = EKP.construct_initial_ensemble(prior, ensemble_size)
 ekp = EKP.EnsembleKalmanProcess(
     user_initial_ensemble,
     observation,
     variance,
     EKP.Inversion();
+    rng = rng_ekp,
     localization_method = EKP.Localizers.NoLocalization(),
     accelerator = EKP.DefaultAccelerator(),
     scheduler = EKP.DefaultScheduler(),


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCalibrate.jl/issues/306

There was a chance that the WorkerBackend calibration test could fail because a random seed is not fixed for EKP and the number of iterations is small. This PR fixes this by setting a random seed for EKP.