### PR TITLE
Add model interface abstract type

### DIFF
--- a/docs/literate_example.jl
+++ b/docs/literate_example.jl
@@ -1,9 +1,9 @@
 # # Distributed Calibration Tutorial Using Julia Workers
 # This example will teach you how to use ClimaCalibrate to parallelize your calibration with workers.
-# Workers are additional processes spun up to run code in a distributed fashion. 
+# Workers are additional processes spun up to run code in a distributed fashion.
 # In this tutorial, we will run ensemble members' forward models on different workers.
 
-# The example calibration uses CliMA's atmosphere model, [`ClimaAtmos.jl`](https://github.com/CliMA/ClimaAtmos.jl/), 
+# The example calibration uses CliMA's atmosphere model, [`ClimaAtmos.jl`](https://github.com/CliMA/ClimaAtmos.jl/),
 # in a column spatial configuration for 30 days to simulate outgoing radiative fluxes.
 # Radiative fluxes are used in the observation map to calibrate the astronomical unit.
 
@@ -15,7 +15,7 @@ using ClimaUtilities.ClimaArtifacts
 import EnsembleKalmanProcesses as EKP
 import EnsembleKalmanProcesses: I, ParameterDistributions.constrained_gaussian
 
-# Next, we add workers. These are primarily added by 
+# Next, we add workers. These are primarily added by
 # [`Distributed.addprocs`](https://docs.julialang.org/en/v1/stdlib/Distributed/#Distributed.addprocs)
 # or by starting Julia with multiple processes: `julia -p <nprocs>`.
 
@@ -63,8 +63,24 @@ mkpath(output_dir)
 # - [`path_to_ensemble_member`](@ref): Returns the ensemble member's output directory
 # - [`parameter_path`](@ref): Returns the ensemble member's parameter file as specified by [`EKP.TOMLInterface`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/TOMLInterface/#EnsembleKalmanProcesses.TOMLInterface.save_parameter_ensemble)
 
-# The forward model below is running `ClimaAtmos.jl` in a minimal `column` spatial configuration.
-@everywhere function CAL.forward_model(iteration, member)
+# The forward model below is running `ClimaAtmos.jl` in a minimal `column`
+# spatial configuration.
+
+# !!! note "Everywhere macro"
+#     Due to limitations in Documenter.jl (see
+#     [here](https://github.com/fredrikekre/Literate.jl/issues/254) and
+#     [here](https://github.com/JuliaDocs/Documenter.jl/issues/1848)), we append
+#     `@eval $(@__MODULE__)` to every `@everywhere` call. For your own
+#     calibration script, you do not need to do this.
+
+@everywhere @eval $(@__MODULE__) struct RadiativeFluxModelInterface <:
+                                        CAL.AbstractModelInterface end
+
+@everywhere @eval $(@__MODULE__) function CAL.forward_model(
+    ::RadiativeFluxModelInterface,
+    iteration,
+    member,
+)
     config_dict = Dict(
         "dt" => "2000secs",
         "t_end" => "30days",
@@ -86,11 +102,11 @@ mkpath(output_dir)
             ),
         ],
     )
-    #md # Set the output path for the current member
+    ## Set the output path for the current member
     member_path = CAL.path_to_ensemble_member(output_dir, iteration, member)
     config_dict["output_dir"] = member_path
 
-    #md # Set the parameters for the current member
+    ## Set the parameters for the current member
     parameter_path = CAL.parameter_path(output_dir, iteration, member)
     if haskey(config_dict, "toml")
         push!(config_dict["toml"], parameter_path)
@@ -98,7 +114,7 @@ mkpath(output_dir)
         config_dict["toml"] = [parameter_path]
     end
 
-    #md # Turn off default diagnostics
+    ## Turn off default diagnostics
     config_dict["output_default_diagnostics"] = false
 
     comms_ctx = ClimaComms.SingletonCommsContext()
@@ -110,11 +126,11 @@ end
 
 # Next, the observation map is required to process a full ensemble of model output
 # for the ensemble update step. The observation map just takes in the iteration number,
-# and always outputs an array. 
+# and always outputs an array.
 # For observation map output `G_ensemble`, `G_ensemble[:, m]` must the output of ensemble member `m`.
 # This is needed for compatibility with EnsembleKalmanProcesses.jl.
 const days = 86_400
-function CAL.observation_map(iteration)
+function CAL.observation_map(::RadiativeFluxModelInterface, iteration)
     single_member_dims = (1,)
     G_ensemble = Array{Float64}(undef, single_member_dims..., ensemble_size)
 
@@ -156,7 +172,7 @@ prior = constrained_gaussian("astronomical_unit", 6e10, 1e11, 2e5, Inf)
 parameter_file = CAL.parameter_path(output_dir, 0, 0)
 mkpath(dirname(parameter_file))
 touch(parameter_file)
-simulation = CAL.forward_model(0, 0)
+simulation = CAL.forward_model(RadiativeFluxModelInterface(), 0, 0)
 # Lastly, we use the observation map itself to generate the observations.
 observations = Vector{Float64}(undef, 1)
 observations .= process_member_data(SimDir(simulation.output_dir))
@@ -175,4 +191,11 @@ ekp = EKP.EnsembleKalmanProcess(
     EKP.Inversion(),
     EKP.default_options_dict(EKP.Inversion()),
 )
-eki = CAL.calibrate(CAL.WorkerBackend(), ekp, n_iterations, prior, output_dir)
+eki = CAL.calibrate(
+    CAL.WorkerBackend(),
+    ekp,
+    RadiativeFluxModelInterface(),
+    n_iterations,
+    prior,
+    output_dir,
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,10 +3,14 @@
 ## Model Interface
 
 ```@docs
+ClimaCalibrate.AbstractModelInterface
 ClimaCalibrate.forward_model
 ClimaCalibrate.observation_map
 ClimaCalibrate.analyze_iteration
 ClimaCalibrate.postprocess_g_ensemble
+ClimaCalibrate.model_interface_filepath
+ClimaCalibrate.experiment_dir
+ClimaCalibrate.exeflags
 ```
 
 ## Calibration Interface

--- a/experiments/surface_fluxes_perfect_model/model_interface.jl
+++ b/experiments/surface_fluxes_perfect_model/model_interface.jl
@@ -24,12 +24,21 @@ We need to follow the following steps for the calibration:
 4. define the prior distributions for θ (this is subjective and can be based on expert knowledge or previous studies)
 """
 
+struct SurfaceFluxModelInterface <: ClimaCalibrate.AbstractModelInterface end
+
 experiment_dir =
     joinpath(pkgdir_CC, "experiments", "surface_fluxes_perfect_model")
+
+ClimaCalibrate.model_interface_filepath(::SurfaceFluxModelInterface) =
+    joinpath(experiment_dir, "model_interface.jl")
 include(joinpath(experiment_dir, "sf_model.jl"))
 include(joinpath(experiment_dir, "observation_map.jl"))
 
-function forward_model(iteration, member)
+function ClimaCalibrate.forward_model(
+    ::SurfaceFluxModelInterface,
+    iteration,
+    member,
+)
     # Specify member path for output_dir
     model_config = Dict()
     output_dir = joinpath(pkgdir_CC, "output", "surface_fluxes_perfect_model")

--- a/experiments/surface_fluxes_perfect_model/observation_map.jl
+++ b/experiments/surface_fluxes_perfect_model/observation_map.jl
@@ -15,7 +15,7 @@ experiment_dir = joinpath(
 Returns the observation map (from the raw model output to the observable y),
 as specified by process_member_data, for the given iteration.
 """
-function observation_map(iteration)
+function ClimaCalibrate.observation_map(::SurfaceFluxModelInterface, iteration)
     model_output = "model_ustar_array.jld2"
 
     dims = 1

--- a/src/ClimaCalibrate.jl
+++ b/src/ClimaCalibrate.jl
@@ -5,6 +5,8 @@ export project_dir
 
 project_dir() = dirname(Base.active_project())
 
+include("model_interface.jl")
+
 include("ekp_utils.jl")
 @reexport using .EKPUtils
 
@@ -14,7 +16,6 @@ include("backend.jl")
 include("calibration.jl")
 @reexport using .Calibration
 
-include("model_interface.jl")
 include("observation_recipe.jl")
 include("ensemble_builder.jl")
 include("checkers.jl")

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -1,7 +1,7 @@
 module Calibration
 
 import ClimaCalibrate
-import ..ClimaCalibrate: Backend
+import ..ClimaCalibrate: Backend, AbstractModelInterface
 import ClimaCalibrate.Backend: HPCBackend, WorkerBackend, JuliaBackend
 
 # Needed for interfacing with WorkerBackend
@@ -17,39 +17,39 @@ include("ekp_interface.jl")
     calibrate(
         backend::HPCBackend,
         ekp::EKP.EnsembleKalmanProcess,
+        interface::AbstractModelInterface,
         n_iterations,
         prior,
         output_dir,
-        model_interface;
-        experiment_dir = project_dir(),
-        exeflags = "",
     )
 
 Run a full calibration with `ekp` and `prior` for `n_iterations` on the given
 `backend`, storing the results of the calibration in `output_dir`.
 
 The work of each ensemble member which is running the forward model is done by
-submitting a job to the `backend`. The `model_interface` file and project
-directory `experiment_dir` should contain all the dependencies to run the
-forward model. The job begins by running
-`julia --project=\$experiment_dir -e 'include(\$model_interface)'` and running
-the forward model.
+submitting a job to the `backend`. The file path returned by
+[`ClimaCalibrate.model_interface_filepath`](@ref) and project directory
+`experiment_dir` should contain all the dependencies to run the forward model.
+The job begins by running `julia --project=\$experiment_dir -e
+'include(\$model_interface_filepath())'` and running the forward model.
+
+The `interface` is serialized to `interface.jld2` in `output_dir`, so that HPC
+job scripts can load and pass it to `forward_model`.
 
 For more information about the `HPCBackend`, see [`HPCBackend`](@ref).
 """
 function calibrate(
     backend::HPCBackend,
     ekp::EKP.EnsembleKalmanProcess,
+    interface::AbstractModelInterface,
     n_iterations,
     prior,
     output_dir,
-    model_interface;
-    experiment_dir = project_dir(),
-    exeflags = "",
 )
     output_dir = abspath(output_dir)
-    experiment_dir = abspath(experiment_dir)
-    model_interface = abspath(model_interface)
+    experiment_dir = abspath(ClimaCalibrate.experiment_dir(interface))
+    model_interface_fp =
+        abspath(ClimaCalibrate.model_interface_filepath(interface))
 
     ensemble_size = EKP.get_N_ens(ekp)
     @info "Initializing calibration" n_iterations ensemble_size output_dir
@@ -58,7 +58,10 @@ function calibrate(
     # Validation checks for output_dir, experiment_dir, and model_interface
     @assert isdir(output_dir) "Output directory does not exist: $output_dir"
     @assert isdir(experiment_dir) "Experiment directory does not exist: $experiment_dir"
-    @assert isfile(model_interface) "Model interface file does not exist: $model_interface"
+    @assert isfile(model_interface_fp) "Model interface file does not exist: $model_interface_fp"
+
+    # Save interface object for HPC job scripts to load
+    JLD2.save_object(joinpath(output_dir, "interface.jld2"), interface)
 
     first_iter = last_completed_iteration(output_dir) + 1
     for iter in first_iter:n_iterations
@@ -68,13 +71,14 @@ function calibrate(
             iter,
             ensemble_size,
             output_dir,
-            model_interface,
+            model_interface_fp,
             experiment_dir,
-            exeflags,
+            ClimaCalibrate.exeflags(interface),
         )
         @info "Completed iteration $iter, updating ensemble"
         ekp = load_ekp_struct(output_dir, iter)
-        terminate = observation_map_and_update!(ekp, output_dir, iter, prior)
+        terminate =
+            observation_map_and_update!(ekp, output_dir, iter, prior, interface)
         !isnothing(terminate) && break
     end
     return ekp
@@ -86,7 +90,7 @@ end
         iter,
         ensemble_size,
         output_dir,
-        model_interface,
+        model_interface_filepath,
         experiment_dir,
         exeflags,
     )
@@ -101,7 +105,7 @@ function run_iteration(
     iter,
     ensemble_size,
     output_dir,
-    model_interface,
+    model_interface_filepath,
     experiment_dir,
     exeflags,
 )
@@ -112,7 +116,7 @@ function run_iteration(
             iter,
             member,
             output_dir,
-            model_interface,
+            model_interface_filepath,
             experiment_dir,
             exeflags,
         )
@@ -146,7 +150,7 @@ end
         iter,
         member,
         output_dir,
-        model_interface,
+        model_interface_filepath,
         experiment_dir,
         exeflags,
     )
@@ -159,7 +163,7 @@ function generate_job_script_for_ensemble_member(
     iter,
     member,
     output_dir,
-    model_interface,
+    model_interface_filepath,
     experiment_dir,
     exeflags,
 )
@@ -167,9 +171,10 @@ function generate_job_script_for_ensemble_member(
     job_body = """
     import ClimaCalibrate
     iteration = $iter; member = $member
-    model_interface = "$model_interface"; include(model_interface)
-    experiment_dir = "$experiment_dir"
-    ClimaCalibrate.forward_model(iteration, member)
+    model_interface_filepath = "$model_interface_filepath"
+    include(model_interface_filepath)
+    interface = ClimaCalibrate._load(joinpath("$output_dir", "interface.jld2"))
+    ClimaCalibrate.forward_model(interface, iteration, member)
     ClimaCalibrate.write_model_completed("$output_dir", iteration, member)
     """
 
@@ -316,6 +321,7 @@ end
     calibrate(
         backend::WorkerBackend,
         ekp::EKP.EnsembleKalmanProcess,
+        interface::AbstractModelInterface,
         n_iterations,
         prior,
         output_dir,
@@ -329,6 +335,7 @@ For more information about the `WorkerBackend`, see [`WorkerBackend`](@ref).
 function calibrate(
     backend::WorkerBackend,
     ekp::EKP.EnsembleKalmanProcess,
+    interface::AbstractModelInterface,
     n_iterations,
     prior,
     output_dir,
@@ -345,30 +352,43 @@ function calibrate(
     first_iter = last_completed_iteration(output_dir) + 1
     for iter in first_iter:n_iterations
         @info "Iteration $iter"
-        run_iteration(backend, iter, ensemble_size, output_dir)
+        run_iteration(backend, interface, iter, ensemble_size, output_dir)
         @info "Completed iteration $iter, updating ensemble"
         ekp = load_ekp_struct(output_dir, iter)
-        terminate = observation_map_and_update!(ekp, output_dir, iter, prior)
+        terminate =
+            observation_map_and_update!(ekp, output_dir, iter, prior, interface)
         !isnothing(terminate) && break
     end
     return ekp
 end
 
 """
-    run_iteration(backend::WorkerBackend, iter, ensemble_size, output_dir)
+    run_iteration(
+        backend::WorkerBackend,
+        interface::AbstractModelInterface,
+        iter,
+        ensemble_size,
+        output_dir,
+    )
 
 Run the `iter`th iteration.
 
 This function submits the work for a single ensemble member to each worker
 and waits for each worker to complete (succeed or fail).
 """
-function run_iteration(backend::WorkerBackend, iter, ensemble_size, output_dir)
+function run_iteration(
+    backend::WorkerBackend,
+    interface::AbstractModelInterface,
+    iter,
+    ensemble_size,
+    output_dir,
+)
     isempty(backend.worker_pool.workers) &&
         @info "No workers currently available"
 
     # For each ensemble member, generate the work that the workers will do
     work_to_do = map(1:ensemble_size) do member
-        prepare_work_for_ensemble_member(iter, member, output_dir)
+        prepare_work_for_ensemble_member(iter, member, output_dir, interface)
     end
 
     (; worker_pool) = backend
@@ -408,11 +428,11 @@ function run_iteration(backend::WorkerBackend, iter, ensemble_size, output_dir)
 end
 
 """
-    prepare_work_for_ensemble_member(iter, member, output_dir)
+    prepare_work_for_ensemble_member(iter, member, output_dir, interface)
 
 Return a function that takes in a worker and run the forward model if needed.
 """
-function prepare_work_for_ensemble_member(iter, member, output_dir)
+function prepare_work_for_ensemble_member(iter, member, output_dir, interface)
     return (worker) -> begin
         if model_completed(output_dir, iter, member)
             @info "Skipping completed member $member (found checkpoint)"
@@ -426,6 +446,7 @@ function prepare_work_for_ensemble_member(iter, member, output_dir)
         Distributed.remotecall_wait(
             ClimaCalibrate.forward_model,
             worker,
+            interface,
             iter,
             member,
         )
@@ -437,6 +458,7 @@ end
     calibrate(
         backend::JuliaBackend,
         ekp::EKP.EnsembleKalmanProcess,
+        interface::AbstractModelInterface,
         n_iterations,
         prior,
         output_dir,
@@ -452,6 +474,7 @@ For more information about the `JuliaBackend`, see [`JuliaBackend`](@ref).
 function calibrate(
     backend::JuliaBackend,
     ekp::EKP.EnsembleKalmanProcess,
+    interface::AbstractModelInterface,
     n_iterations,
     prior,
     output_dir,
@@ -468,22 +491,35 @@ function calibrate(
     first_iter = last_completed_iteration(output_dir) + 1
     for iter in first_iter:n_iterations
         @info "Iteration $iter"
-        run_iteration(backend, iter, ensemble_size, output_dir)
+        run_iteration(backend, interface, iter, ensemble_size, output_dir)
         @info "Completed iteration $iter, updating ensemble"
         ekp = load_ekp_struct(output_dir, iter)
-        terminate = observation_map_and_update!(ekp, output_dir, iter, prior)
+        terminate =
+            observation_map_and_update!(ekp, output_dir, iter, prior, interface)
         !isnothing(terminate) && break
     end
     return ekp
 end
 
 """
-    run_iteration(backend::JuliaBackend, iter, ensemble_size, output_dir)
+    run_iteration(
+        ::JuliaBackend,
+        interface::AbstractModelInterface,
+        iter,
+        ensemble_size,
+        output_dir,
+    )
 
 Run the `iter`th iteration by completing the work of all the ensemble members
 sequentially.
 """
-function run_iteration(::JuliaBackend, iter, ensemble_size, output_dir)
+function run_iteration(
+    ::JuliaBackend,
+    interface::AbstractModelInterface,
+    iter,
+    ensemble_size,
+    output_dir,
+)
     on_error(e::InterruptException) = rethrow(e)
     on_error(e) =
         @error "Single ensemble member has errored. See stacktrace" exception =
@@ -492,7 +528,7 @@ function run_iteration(::JuliaBackend, iter, ensemble_size, output_dir)
     failures = 0
     foreach(1:ensemble_size) do m
         try
-            ClimaCalibrate.forward_model(iter, m)
+            ClimaCalibrate.forward_model(interface, iter, m)
             @info "Completed member $m"
         catch e
             failures += 1

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -237,13 +237,26 @@ function update_ensemble!(ekp, G_ens, output_dir, iteration, prior)
 end
 
 """
-    observation_map_and_update!(ekp, output_dir, iteration, prior)
+    observation_map_and_update!(
+        ekp,
+        output_dir,
+        iteration,
+        prior,
+        interface,
+    )
 
 Compute the observation map and update the given EKP object.
 """
-function observation_map_and_update!(ekp, output_dir, iteration, prior)
-    g_ensemble = ClimaCalibrate.observation_map(iteration)
+function observation_map_and_update!(
+    ekp,
+    output_dir,
+    iteration,
+    prior,
+    interface,
+)
+    g_ensemble = ClimaCalibrate.observation_map(interface, iteration)
     g_ensemble = ClimaCalibrate.postprocess_g_ensemble(
+        interface,
         ekp,
         g_ensemble,
         prior,
@@ -254,6 +267,7 @@ function observation_map_and_update!(ekp, output_dir, iteration, prior)
     terminate = update_ensemble!(ekp, g_ensemble, output_dir, iteration, prior)
     try
         ClimaCalibrate.analyze_iteration(
+            interface,
             ekp,
             g_ensemble,
             prior,

--- a/src/model_interface.jl
+++ b/src/model_interface.jl
@@ -1,32 +1,98 @@
 import EnsembleKalmanProcesses as EKP
+import JLD2
 import YAML
 
-export forward_model, observation_map, analyze_iteration
+export AbstractModelInterface,
+    forward_model,
+    observation_map,
+    analyze_iteration,
+    postprocess_g_ensemble,
+    model_interface_filepath,
+    experiment_dir,
+    exeflags
 
 """
-    forward_model(iteration, member)
+    AbstractModelInterface
+
+Abstract supertype for user-defined calibration experiments.
+
+Users subtype this to define their experiment-specific configuration and
+dispatch the calibration interface functions.
+
+# Required interface
+
+Subtypes must implement:
+- `forward_model(interface, iteration, member)` which runs the forward model for a
+  single ensemble member.
+- `observation_map(interface, iteration)` which processes model output and,
+  returns a `G_ensemble` matrix.
+
+To use the `HPCBackend`, the subtypes must also implement:
+- `model_interface_filepath(interface)` which returns the path to the file that
+  defines the model interface. The `HPCBackend` job script includes this file so
+  that all interface functions defined on the subtype are available in the worker
+  process.
+
+# Optional interface
+
+- `analyze_iteration(interface, ekp, g_ensemble, prior, iteration)` which
+  inspect results after each ensemble update. The default implementation logs
+  the mean constrained parameters and covariance-weighted error.
+- `postprocess_g_ensemble(interface, ekp, g_ensemble, prior, iteration)` which
+  transform `g_ensemble` before the ensemble update. The default implementation
+  returns `g_ensemble`.
+
+For `HPCBackend`, the subtypes can also implement:
+- `experiment_dir(interface)` which returns the Julia project directory passed
+  as `--project` to the job script. The default implementation is to return
+  `project_dir()`.
+- `exeflags(interface)` which returns additional flags (e.g. `--threads 4`)
+  passed to the Julia executable in the job script. The default implementation
+  is to return the empty string.
+
+# Example
+
+```julia
+struct MyModelInterface <: ClimaCalibrate.AbstractModelInterface
+    config::String
+end
+
+function ClimaCalibrate.forward_model(interface::MyModelInterface, iteration, member)
+    # Run the model using interface.config
+end
+
+function ClimaCalibrate.observation_map(interface::MyModelInterface, iteration)
+    # Read model outputs and return G_ensemble matrix
+end
+```
+"""
+abstract type AbstractModelInterface end
+
+"""
+    forward_model(interface::AbstractModelInterface, iteration, member)
 
 Execute the forward model simulation with the given configuration.
 
-This function must be overridden by a component's model interface and 
-should set things like the parameter path and other member-specific settings.
+This function must be overridden by the user's model interface,
+dispatching on their subtype of `AbstractModelInterface`.
 """
-function forward_model(iteration, member)
-    error("forward_model not implemented")
+function forward_model(interface::AbstractModelInterface, iteration, member)
+    error("forward_model not implemented for $(nameof(typeof(interface)))")
 end
 
 """
-    observation_map(iteration)
+    observation_map(interface::AbstractModelInterface, iteration)
 
 Runs the observation map for the specified iteration.
-This function must be implemented for each calibration experiment.
+This function must be implemented for each calibration experiment,
+dispatching on the user's subtype of `AbstractModelInterface`.
 """
-function observation_map(iteration)
-    error("observation_map not implemented")
+function observation_map(interface::AbstractModelInterface, iteration)
+    error("observation_map not implemented for $(nameof(typeof(interface)))")
 end
 
 """
-    analyze_iteration(ekp, g_ensemble, prior, output_dir, iteration)
+    analyze_iteration(interface::AbstractModelInterface, ekp, g_ensemble, prior, iteration)
 
 After updating the ensemble and before starting the next iteration,
 `analyze_iteration` is evaluated.
@@ -36,18 +102,100 @@ This function is optional to implement.
 For example, one may want to print information from the `eki` object or plot
 `g_ensemble`.
 """
-function analyze_iteration(ekp, g_ensemble, prior, output_dir, iteration)
+function analyze_iteration(
+    ::AbstractModelInterface,
+    ekp,
+    g_ensemble,
+    prior,
+    output_dir,
+    iteration,
+)
     @info "Mean constrained parameter(s): $(EKP.get_ϕ_mean_final(prior, ekp))"
     @info "Covariance-weighted error: $(last(EKP.get_error(ekp)))"
     return nothing
 end
 
 """
-    postprocess_g_ensemble(ekp, g_ensemble, prior, output_dir, iteration)
+    postprocess_g_ensemble(
+        interface::AbstractModelInterface,
+        ekp,
+        g_ensemble,
+        prior,
+        iteration
+    )
 
 Postprocess `g_ensemble` after evaluating the observation map and before
 updating the ensemble.
 """
-function postprocess_g_ensemble(ekp, g_ensemble, prior, output_dir, iteration)
+function postprocess_g_ensemble(
+    ::AbstractModelInterface,
+    ekp,
+    g_ensemble,
+    prior,
+    output_dir,
+    iteration,
+)
     return g_ensemble
 end
+
+"""
+    model_interface_filepath(interface::AbstractModelInterface)
+
+Return the path to the file that defines the model interface.
+
+The [`HPCBackend`](@ref) job script includes this file so that all interface
+functions defined on the `AbstractModelInterface` subtype (e.g.
+[`forward_model`](@ref), [`observation_map`](@ref), and any optional overrides)
+are available in the worker process, along with their required packages.
+"""
+function model_interface_filepath(interface::AbstractModelInterface)
+    error(
+        "model_interface_filepath not implemented for $(nameof(typeof(interface)))",
+    )
+end
+
+"""
+    experiment_dir(interface::AbstractModelInterface)
+
+Return the path to the experiment's Julia project directory.
+
+The [`HPCBackend`](@ref) uses this to construct the job script command:
+```
+julia --project=\$experiment_dir \$exeflags -e '...'
+```
+so that each ensemble member's forward model job runs with the correct project
+environment. By default, returns `project_dir()` (the currently active project).
+
+You should override this in your `AbstractModelInterface` subtype if your
+experiment lives in a separate project directory.
+"""
+function experiment_dir(::AbstractModelInterface)
+    return project_dir()
+end
+
+"""
+    exeflags(::AbstractModelInterface)
+
+Return additional flags passed to the Julia executable in the `HPCBackend` job
+script.
+
+The [`HPCBackend`](@ref) constructs each ensemble member's job command as:
+```
+julia --project=\$experiment_dir \$exeflags -e '...'
+```
+Override this in your `AbstractModelInterface` subtype to pass extra flags such
+as `--threads` or `-O0`. By default, returns `""` (no extra flags).
+"""
+function exeflags(::AbstractModelInterface)
+    return ""
+end
+
+"""
+    _load(filename)
+
+Load the object with the name `filename`.
+
+This is used by calibration with the `HPCBackend` to support loading the
+model interface object.
+"""
+_load(filename) = JLD2.load_object(filename)

--- a/test/hpc_backend.jl
+++ b/test/hpc_backend.jl
@@ -31,11 +31,15 @@ else
     hpc_config = ClimaCalibrate.SlurmConfig(; directives, modules)
 end
 
-original_model_interface = model_interface
 interruption_model_interface, io = mktemp(@__DIR__)
+
+struct CancelModelInterface <: ClimaCalibrate.AbstractModelInterface end
+ClimaCalibrate.forward_model(::CancelModelInterface, i, m) = m == 1 && exit()
 model_interface_str = """
 import ClimaCalibrate
-ClimaCalibrate.forward_model(iter, member) = member == 1 && exit()
+struct CancelModelInterface <: ClimaCalibrate.AbstractModelInterface end
+ClimaCalibrate.forward_model(::CancelModelInterface, i, m) =
+    m == 1 && exit()
 """
 write(io, model_interface_str)
 close(io)
@@ -87,6 +91,9 @@ ClimaCalibrate.initialize(eki, prior, output_dir)
 
 backend = backend(hpc_config)
 experiment_dir = dirname(Base.active_project())
+
+# run_iteration assumes this object exists
+JLD2.save_object(joinpath(output_dir, "interface.jld2"), CancelModelInterface())
 ClimaCalibrate.Calibration.run_iteration(
     backend,
     1,
@@ -119,11 +126,10 @@ backend = ClimaCalibrate.get_backend()
 eki = ClimaCalibrate.Calibration.calibrate(
     backend(hpc_config),
     ekp,
+    SurfaceFluxModelInterface(),
     n_iterations,
     prior,
     output_dir,
-    model_interface;
-    experiment_dir,
 )
 
 @test ClimaCalibrate.last_completed_iteration(output_dir) == n_iterations
@@ -153,6 +159,7 @@ ekp = make_ekp(
 julia_eki = ClimaCalibrate.Calibration.calibrate(
     JuliaBackend(),
     ekp,
+    SurfaceFluxModelInterface(),
     n_iterations,
     prior,
     output_dir,

--- a/test/julia_backend.jl
+++ b/test/julia_backend.jl
@@ -18,10 +18,12 @@ observations = [20.0]
 noise = [0.01;;]
 output_dir = mktempdir()
 
+struct DummyModelInterface <: CAL.AbstractModelInterface end
+
 # Model interface
 # This "model" just samples parameters and returns them, we are checking that
 # the results are reproducible
-function CAL.forward_model(iteration, member)
+function CAL.forward_model(::DummyModelInterface, iteration, member)
     member_path = CAL.path_to_ensemble_member(output_dir, iteration, member)
     param_path = CAL.parameter_path(output_dir, iteration, member)
     toml_dict = CP.create_toml_dict(Float64; override_file = param_path)
@@ -29,7 +31,7 @@ function CAL.forward_model(iteration, member)
     JLD2.save_object(joinpath(member_path, output_file), test_param)
 end
 
-function CAL.observation_map(iteration)
+function CAL.observation_map(::DummyModelInterface, iteration)
     dims = 1
     G_ensemble = Array{Float64}(undef, dims..., ensemble_size)
     for m in 1:ensemble_size
@@ -41,7 +43,14 @@ function CAL.observation_map(iteration)
     return G_ensemble
 end
 
-function CAL.analyze_iteration(ekp, g_ensemble, prior, output_dir, iteration)
+function CAL.analyze_iteration(
+    ::DummyModelInterface,
+    ekp,
+    g_ensemble,
+    prior,
+    output_dir,
+    iteration,
+)
     @info "Analyzing iteration"
     @info "Iteration $iteration"
     @info "Current mean constrained parameter: $(EKP.get_ϕ_mean_final(prior, ekp))"
@@ -61,6 +70,7 @@ eki = EKP.EnsembleKalmanProcess(
 ekp = CAL.Calibration.calibrate(
     CAL.JuliaBackend(),
     eki,
+    DummyModelInterface(),
     n_iterations,
     prior,
     output_dir,

--- a/test/model_interface.jl
+++ b/test/model_interface.jl
@@ -8,14 +8,22 @@ using Test
 # error. However, `analyze_iteration` and `postprocess_g_ensemble` are
 # optional to implement.
 
+struct DummyModelInterface <: ClimaCalibrate.AbstractModelInterface end
+
 @testset "Model Interface stubs" begin
-    @test_throws ErrorException("forward_model not implemented") ClimaCalibrate.forward_model(
-        1,
-        1,
-    )
-    @test_throws ErrorException("observation_map not implemented") ClimaCalibrate.observation_map(
-        1,
-    )
-    @test isnothing(ClimaCalibrate.analyze_iteration(1, 1, 1, 1, 1))
-    @test 2 == ClimaCalibrate.postprocess_g_ensemble(1, 2, 3, 4, 5)
+    interface = DummyModelInterface()
+    @test_throws ErrorException(
+        "forward_model not implemented for DummyModelInterface",
+    ) ClimaCalibrate.forward_model(interface, 1, 1)
+    @test_throws ErrorException(
+        "observation_map not implemented for DummyModelInterface",
+    ) ClimaCalibrate.observation_map(interface, 1)
+    @test isnothing(ClimaCalibrate.analyze_iteration(interface, 1, 1, 1, 1, 1))
+    @test 2 == ClimaCalibrate.postprocess_g_ensemble(interface, 1, 2, 3, 4, 5)
+    @test_throws ErrorException(
+        "model_interface_filepath not implemented for DummyModelInterface",
+    ) ClimaCalibrate.model_interface_filepath(DummyModelInterface())
+    @test ClimaCalibrate.experiment_dir(DummyModelInterface()) ==
+          ClimaCalibrate.project_dir()
+    @test ClimaCalibrate.exeflags(DummyModelInterface()) == ""
 end

--- a/test/worker_backend.jl
+++ b/test/worker_backend.jl
@@ -28,7 +28,9 @@ if nworkers() == 1
 end
 
 @everywhere using ClimaCalibrate
-@everywhere ClimaCalibrate.forward_model(i, m) = m == 1 && exit()
+@everywhere struct CancelModelInterface <: ClimaCalibrate.AbstractModelInterface end
+@everywhere ClimaCalibrate.forward_model(::CancelModelInterface, i, m) =
+    m == 1 && exit()
 
 eki = EKP.EnsembleKalmanProcess(
     EKP.construct_initial_ensemble(prior, ensemble_size),
@@ -42,6 +44,7 @@ ClimaCalibrate.initialize(eki, prior, output_dir)
 
 ClimaCalibrate.Calibration.run_iteration(
     ClimaCalibrate.WorkerBackend(),
+    CancelModelInterface(),
     1,
     ensemble_size,
     output_dir,
@@ -81,6 +84,7 @@ ekp = EKP.EnsembleKalmanProcess(
 eki = ClimaCalibrate.Calibration.calibrate(
     ClimaCalibrate.WorkerBackend(),
     ekp,
+    SurfaceFluxModelInterface(),
     n_iterations,
     prior,
     output_dir,
@@ -108,11 +112,15 @@ g_vs_iter_plot(eki, output_dir)
     @test last_iter == n_iterations
     ClimaCalibrate.Calibration.run_iteration(
         ClimaCalibrate.WorkerBackend(),
+        SurfaceFluxModelInterface(),
         last_iter + 1,
         ensemble_size,
         output_dir,
     )
-    G_ensemble = ClimaCalibrate.observation_map(last_iter + 1)
+    G_ensemble = ClimaCalibrate.observation_map(
+        SurfaceFluxModelInterface(),
+        last_iter + 1,
+    )
     ClimaCalibrate.save_G_ensemble(output_dir, last_iter + 1, G_ensemble)
     ClimaCalibrate.update_ensemble(output_dir, last_iter + 1, prior)
 


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCalibrate.jl/issues/281

This PR adds the abstract type `AbstractModelInterface` that the user can subtype. This removes the type piracy that the user needed to do before and allows for the user to implement multiple concrete types of an `AbstractModelInterface` for supporting multiple calibration. For instance, in the coupler calibration pipeline, both subseasonal and AMIP calibration can be support with the type hierarchy
1. `AMIPModelInterface <: AbstractCouplerModelInterface`,
2. `SubseasonalModelInterface <: AbstractCouplerModelInterface`,
3. `AbstractCouplerModelInterface <: AbstractModelInterface`.

The `AbstractCouplerModelInterface` can provide default for the forward model, but the observation map can differ between the `AMIPModelInterface` and `SubseasonalModelInterface`.