### PR TITLE
Clean up docs and small issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,43 @@
 ClimaCalibrate.jl Release Notes
 ========================
 
-main
+v0.3.0
 -------
 
-- Add noise covariance and residual analysis tools [#286](https://github.com/CliMA/ClimaCalibrate.jl/pull/286)
+- Refactor codebase into three modules
+  [#295](https://github.com/CliMA/ClimaCalibrate.jl/pull/295):
+  - `EKPUtils`: standalone EKP utility functions with no dependency on the rest
+    of ClimaCalibrate
+  - `BackendManager`: handles job submission for `HPCBackend`s (Slurm/PBS
+    scripts)
+  - `Calibration`: orchestrates the calibration loop, using the `BackendManager`
+    module for job dispatch
+- Add `SlurmConfig` and `PBSConfig` structs for `HPCBackend`s, allowing users to
+  specify job directives, environment variables, and modules to load
+  [#303](https://github.com/CliMA/ClimaCalibrate.jl/pull/303)
+- Add `AbstractModelInterface` abstract type; users subtype this to define their
+  model interface struct
+  [#312](https://github.com/CliMA/ClimaCalibrate.jl/pull/312)
+- Improve general documentation
+  [#314](https://github.com/CliMA/ClimaCalibrate.jl/pull/314)
+- Update climacommon for `ClimaGPUBackend`
+  [#289](https://github.com/CliMA/ClimaCalibrate.jl/pull/289)
+- Add noise covariance and residual analysis tools
+  [#286](https://github.com/CliMA/ClimaCalibrate.jl/pull/286)
+- Remove unused functionality and cleanup
+  [#293](https://github.com/CliMA/ClimaCalibrate.jl/pull/293),
+  [#298](https://github.com/CliMA/ClimaCalibrate.jl/pull/298),
+  [#302](https://github.com/CliMA/ClimaCalibrate.jl/pull/302),
+  [#305](https://github.com/CliMA/ClimaCalibrate.jl/pull/305)
+- Bug fix with analyze_residual
+  [#301](https://github.com/CliMA/ClimaCalibrate.jl/pull/301)
 
 v0.2.2
 -------
-- Add quantile regularization to the SVDPlusDCovariance [#277](https://github.com/CliMA/ClimaCalibrate.jl/pull/277)
+- Add quantile regularization to the SVDPlusDCovariance
+  [#277](https://github.com/CliMA/ClimaCalibrate.jl/pull/277)
 
 v0.2.0
 -------
-- Refactor backend structs to store relevant information [#245](https://github.com/CliMA/ClimaCalibrate.jl/pull/245)
+- Refactor backend structs to store relevant information
+  [#245](https://github.com/CliMA/ClimaCalibrate.jl/pull/245)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCalibrate"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 NaNStatistics = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
 
 [extensions]
-ClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
+ClimaCalibrateClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
 
 [compat]
 Aqua = "0.8"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ calibration pipelines using minimal boilerplate.</strong>
 
 The recommended Julia version is: Stable release v1.11.4
 
-Currently supported backends: 
-- [Resnick High Performance Computing Center](https://www.hpc.caltech.edu/)
-- [NSF NCAR Supercomputer Derecho](https://ncar-hpc-docs.readthedocs.io/en/latest/compute-systems/derecho/)
-- CliMA's private GPU server
+ClimaCalibrate supports different backends for calibration from
+- the Julia backend for single-process calibration,
+- [Distributed.jl](https://github.com/JuliaLang/Distributed.jl) with support for
+  Slurm and PBS job schedulers,
+- [Resnick High Performance Computing Center](https://www.hpc.caltech.edu/),
+- [NSF NCAR Supercomputer Derecho](https://ncar-hpc-docs.readthedocs.io/en/latest/compute-systems/derecho/),
+- CliMA's private GPU server.
 
 ## Contributing
 

--- a/docs/literate_example.jl
+++ b/docs/literate_example.jl
@@ -1,7 +1,8 @@
 # # Distributed Calibration Tutorial Using Julia Workers
-# This example will teach you how to use ClimaCalibrate to parallelize your calibration with workers.
-# Workers are additional processes spun up to run code in a distributed fashion.
-# In this tutorial, we will run ensemble members' forward models on different workers.
+# This example will teach you how to use ClimaCalibrate to parallelize your
+# calibration with workers. Workers are additional processes spun up to run code
+# in a distributed fashion. In this tutorial, we will run ensemble members'
+# forward models on different workers.
 
 # The example calibration uses CliMA's atmosphere model, [`ClimaAtmos.jl`](https://github.com/CliMA/ClimaAtmos.jl/),
 # in a column spatial configuration for 30 days to simulate outgoing radiative fluxes.
@@ -19,9 +20,11 @@ import EnsembleKalmanProcesses: I, ParameterDistributions.constrained_gaussian
 # [`Distributed.addprocs`](https://docs.julialang.org/en/v1/stdlib/Distributed/#Distributed.addprocs)
 # or by starting Julia with multiple processes: `julia -p <nprocs>`.
 
-# `addprocs` itself initializes the workers and registers them with the main Julia process, but there are multiple ways to call it.
-# The simplest is just `addprocs(nprocs)`, which will create new local processes on your machine.
-# The other is to use [`SlurmManager`](@ref), which will acquire and start workers on Slurm resources.
+# `addprocs` itself initializes the workers and registers them with the main
+# Julia process, but there are multiple ways to call it. The simplest is just
+# `addprocs(nprocs)`, which will create new local processes on your machine.
+# The other is to use [`SlurmManager`](@ref), which will acquire and start
+# workers on Slurm resources.
 # You can use keyword arguments to specify the Slurm resources:
 
 # `addprocs(ClimaCalibrate.SlurmManager(nprocs), gpus_per_task = 1, time = "01:00:00")`
@@ -36,13 +39,14 @@ nworkers()
 #-
 workers()
 
-# We can call functions on the worker using [`remotecall`](https://docs.julialang.org/en/v1/stdlib/Distributed/#Distributed.remotecall_fetch-Tuple{Any,%20Integer,%20Vararg{Any}}). 
+# We can call functions on the worker using [`remotecall`](https://docs.julialang.org/en/v1/stdlib/Distributed/#Distributed.remotecall_fetch-Tuple{Any,%20Integer,%20Vararg{Any}}).
 # We pass in the function name and the worker ID followed by the function arguments.
 remotecall_fetch(*, 1, 4, 4)
 # ClimaCalibrate uses this functionality to run the forward model on workers.
 
-# Since the workers start in their own Julia sessions, we need to import packages and declare variables.
-# `Distributed.@everywhere` executes code on all workers, allowing us to load the code that they need.
+# Since the workers start in their own Julia sessions, we need to import
+# packages and declare variables. `Distributed.@everywhere` executes code on all
+# workers, allowing us to load the code that they need.
 @everywhere begin
     output_dir = joinpath("output", "climaatmos_calibration")
     import ClimaCalibrate as CAL
@@ -52,16 +56,24 @@ end
 output_dir = joinpath("output", "climaatmos_calibration")
 mkpath(output_dir)
 
-# First, we need to set up the forward model, which take in the sampled parameters,
-# runs, and saves diagnostic output that can be processed and compared to observations. The 
-# forward model must override `ClimaCalibrate.forward_model(iteration, member)`,
-# since the workers will run this function in parallel.
+# First, we define `RadiativeFluxModelInterface` which will subtype the
+# `ClimaCalibrate.AbstractModelInterface`. The `RadiativeFluxModelInterface`
+# will define how to run the forward model and observation map.
 
-# Since `forward_model(iteration, member)` only takes in the iteration and member numbers, 
-# so we need to use these as hooks to set the model parameters and output directory.
+# The forward model takes in the sampled parameters, runs the simulation, and
+# saves the diagnostic output that can be processed and compared to
+# observations. This is defined by
+# `ClimaCalibrate.forward_model(interface, iteration, member)`. This function
+# is ran in parallel by the `WorkerBackend` and the `HPCBackend`s.
+
+# Since `forward_model(interface, iteration, member)` only takes in the
+# iteration and member numbers, so we need to use these as hooks to set the
+# model parameters and output directory.
 # Two useful functions:
-# - [`path_to_ensemble_member`](@ref): Returns the ensemble member's output directory
-# - [`parameter_path`](@ref): Returns the ensemble member's parameter file as specified by [`EKP.TOMLInterface`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/TOMLInterface/#EnsembleKalmanProcesses.TOMLInterface.save_parameter_ensemble)
+# - [`path_to_ensemble_member`](@ref): Returns the ensemble member's output
+#   directory
+# - [`parameter_path`](@ref): Returns the ensemble member's parameter file as
+#   specified by [`EKP.TOMLInterface`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/TOMLInterface/#EnsembleKalmanProcesses.TOMLInterface.save_parameter_ensemble)
 
 # The forward model below is running `ClimaAtmos.jl` in a minimal `column`
 # spatial configuration.
@@ -125,9 +137,10 @@ mkpath(output_dir)
 end
 
 # Next, the observation map is required to process a full ensemble of model output
-# for the ensemble update step. The observation map just takes in the iteration number,
-# and always outputs an array.
-# For observation map output `G_ensemble`, `G_ensemble[:, m]` must the output of ensemble member `m`.
+# for the ensemble update step. The observation map just takes in the iteration
+# number, and always outputs an array.
+# For observation map output `G_ensemble`, `G_ensemble[:, m]` must the output of
+# ensemble member `m`.
 # This is needed for compatibility with EnsembleKalmanProcesses.jl.
 const days = 86_400
 function CAL.observation_map(::RadiativeFluxModelInterface, iteration)
@@ -177,12 +190,15 @@ simulation = CAL.forward_model(RadiativeFluxModelInterface(), 0, 0)
 observations = Vector{Float64}(undef, 1)
 observations .= process_member_data(SimDir(simulation.output_dir))
 
-# Now we are ready to run our calibration, putting it all together using the 
+# Now we are ready to run our calibration, putting it all together using the
 # `calibrate` function. The `WorkerBackend` will automatically use all workers
 # available to the main Julia process.
-# Other backends are available for forward models that can't use workers or need to be parallelized internally.
-# The simplest backend is the `JuliaBackend`, which runs all ensemble members sequentially and does not require `Distributed.jl`.
-# For more information, see the [`Backends`](https://clima.github.io/ClimaCalibrate.jl/dev/backends/) page.
+# Other backends are available for forward models that can't use workers or need
+# to be parallelized internally.
+# The simplest backend is the `JuliaBackend`, which runs all ensemble members
+# sequentially and does not require `Distributed.jl`.
+# For more information, see the [`Backends`](https://clima.github.io/ClimaCalibrate.jl/dev/backends/)
+# page.
 user_initial_ensemble = EKP.construct_initial_ensemble(prior, ensemble_size)
 ekp = EKP.EnsembleKalmanProcess(
     user_initial_ensemble,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,10 +17,11 @@ Literate.markdown(
     joinpath(@__DIR__, "src"),
 )
 
-ClimaAnalysisExt = Base.get_extension(ClimaCalibrate, :ClimaAnalysisExt)
+ClimaCalibrateClimaAnalysisExt =
+    Base.get_extension(ClimaCalibrate, :ClimaCalibrateClimaAnalysisExt)
 makedocs(
     plugins = [bib],
-    modules = [ClimaCalibrate, ClimaAnalysisExt],
+    modules = [ClimaCalibrate, ClimaCalibrateClimaAnalysisExt],
     sitename = "ClimaCalibrate.jl",
     authors = "Clima",
     checkdocs = :exports,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -143,7 +143,7 @@ ClimaCalibrate.compute_normalized_projections
 ## Ensemble Builder Interface
 
 ```@docs
-ClimaAnalysisExt.GEnsembleBuilder
+ClimaCalibrateClimaAnalysisExt.GEnsembleBuilder
 ClimaCalibrate.EnsembleBuilder.GEnsembleBuilder
 ClimaCalibrate.EnsembleBuilder.fill_g_ens_col!
 ClimaCalibrate.EnsembleBuilder.is_complete

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -95,6 +95,8 @@ ClimaCalibrate.path_to_model_log
 ClimaCalibrate.parameter_path
 ClimaCalibrate.checkpoint_path
 ClimaCalibrate.load_latest_ekp
+ClimaCalibrate.load_ekp_struct
+ClimaCalibrate.ekp_path
 ClimaCalibrate.save_eki_and_parameters
 ```
 

--- a/docs/src/ensemble_builder.md
+++ b/docs/src/ensemble_builder.md
@@ -1,20 +1,24 @@
 # Building G ensemble matrix
 
-!!! warning
-    To enable this module, use `using ClimaAnalysis` or `import ClimaAnalysis`.
+!!! note
+    If you are not using ClimaAnalysis, you can skip this page. To enable this
+    module, use `using ClimaAnalysis` or `import ClimaAnalysis`. This module
+    requires a version of ClimaAnalysis greater than v0.5.19.
 
 !!! note "Prerequisites"
     This module assumes that you are using `ObservationRecipe` to make your
     observations and `ClimaAnalysis` to preprocess your simulation data. If that
     is not the case, this module is not for you.
 
-!!! note "Version of ClimaAnalysis"
-    This module requires a version of ClimaAnalysis greater than v0.5.19.
-
 !!! note "Other documentation"
     It may be helpful to review the documentation for
     [`FlatVar`](https://clima.github.io/ClimaAnalysis.jl/dev/flat/) in
     ClimaAnalysis and [`ObservationRecipe`](@ref) in ClimaCalibrate.
+
+Calibration involves implementing an [`observation_map`](@ref) by hand which
+postprocess, slice, and stack simulation diagnostics into vectors.
+`GEnsembleBuilder` automates this, using the metadata baked into your
+ObservationRecipe observations to match, validate, and fill each column for you.
 
 To help with constructing G ensemble matrix when using `ObservationRecipe`,
 `ClimaCalibrate` provides the struct `GEnsembleBuilder` and its related
@@ -130,6 +134,75 @@ return it from `ClimaCalibrate.observation_map`.
 
 ```julia
 g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+```
+
+## Example
+
+A complete example of using the `GEnsembleBuilder` looks like this.
+
+```julia
+import ClimaCalibrate
+import ClimaCalibrate.EnsembleBuilder
+
+function ClimaCalibrate.observation_map(interface::MyModelInterface, iteration)
+    # In this example, output_dir is stored in interface as a field
+    (; output_dir) = interface
+    ekp = JLD2.load_object(ClimaCalibrate.ekp_path(output_dir, iteration))
+    ensemble_size = EKP.get_N_ens(ekp)
+
+    g_ens_builder = EnsembleBuilder.GEnsembleBuilder(ekp)
+    for m in 1:ensemble_size
+        try
+        member_path =
+            ClimaCalibrate.path_to_ensemble_member(output_dir, iteration, m)
+        diagnostics_path = joinpath(member_path, "output_active")
+        @info "Processing member $m: $diagnostics_path"
+            process_member_data!(g_ens_builder, m, diagnostics_path)
+        catch e
+            @error "Error processing member $m, filling observation map entry with NaNs" exception =
+                e
+            EnsembleBuilder.fill_g_ens_col!(g_ens_builder, m, NaN)
+        end
+    end
+
+    if EnsembleBuilder.is_complete(g_ens_builder)
+        return EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    else
+        @error "G ensemble matrix is not completed. You may find it useful to call `EnsembleBuilder.missing_short_names(g_ens_builder, 1) or display the GEnsembleBuilder object in the REPL"
+    end
+end
+
+function process_member_data!(
+    g_ens_builder,
+    col_idx,
+    diagnostics_folder_path,
+)
+    # The implementation of preprocess differs for each calibration pipeline,
+    # but this load and preprocess OutputVars using ClimaAnalysis
+    vars = preprocess(m, diagnostics_folder_path)
+
+    # It is strongly recommended to use SequentialIndicesChecker
+    seq_indices_checker = Checker.SequentialIndicesChecker()
+    checkers = (seq_indices_checker,)
+
+    # fill_g_ens_col! will remove the spinup and is mask-aware.
+    # g_ens_builder contain the metadata from the observations, so
+    # fill_g_ens_col! will only choose values over temporal and spatial
+    # coordinates that exist in the observational data
+    for var in vars
+        use_var = EnsembleBuilder.fill_g_ens_col!(
+            g_ens_builder,
+            col_idx,
+            var;
+            checkers,
+            verbose = true,
+        )
+        use_var || error(
+            "OutputVar with short name ($(ClimaAnalysis.short_name(var))) was passed, but not used",
+        )
+    end
+    return nothing
+end
 ```
 
 # Checkers

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,9 +9,12 @@ Key Features
 
 - Distributed computing support for multiple HPC environments via a backend
   system
+- Support for Distributed.jl with Slurm and PBS job schedulers
 - Integration with EnsembleKalmanProcesses.jl for parameter estimation
 - Flexible model interface for different component models
 - Reusable recipes for creating observations from ClimaAnalysis.jl `OutputVar`s
+- G ensemble builder for simplifying the construction of the G ensemble matrix
+- `SVDplusD` covariance matrix analysis
 
 For more information, see our
 [Getting Started page](https://clima.github.io/ClimaCalibrate.jl/dev/quickstart/).

--- a/docs/src/observation_recipe.md
+++ b/docs/src/observation_recipe.md
@@ -1,6 +1,9 @@
 # ObservationRecipe
 
 !!! warning
+    If you are not using ClimaAnalysis, you can skip this page.
+
+!!! warning
     To enable this module, use `using ClimaAnalysis` or `import
     ClimaAnalysis`.
 

--- a/docs/src/precompilation.md
+++ b/docs/src/precompilation.md
@@ -1,14 +1,23 @@
 # Using PrecompileTools for faster model runs
 
-PrecompileTools.jl enables developers to force the Julia compiler to save more code to disk, preventing re-compilation in the future.
+PrecompileTools.jl enables developers to force the Julia compiler to save more
+code to disk, preventing re-compilation in the future.
 
 For ClimaCalibrate, this is useful under certain conditions:
-1. **The atmosphere model configuration is set and will not change often**. This is because the model configuration specifies things like the floating-point type and callbacks, which affect the MethodInstances that get precompiled. Generically precompiling ClimaAtmos would take much too long to be useful.
-2. **The model runtime is short compared to the compile time.** If the model runtime is an order of magnitude or more than the compilation time, any benefit from reduced compilation time will be trivial.
+1. **The atmosphere model configuration is set and will not change often**. This
+   is because the model configuration specifies things like the floating-point
+   type and callbacks, which affect the MethodInstances that get precompiled.
+   Generically precompiling ClimaAtmos would take much too long to be useful.
+2. **The model runtime is short compared to the compile time.** If the model
+   runtime is an order of magnitude or more than the compilation time, any
+   benefit from reduced compilation time will be trivial.
 
 # How do I precompile my configuration?
-The easiest way is by copying and pasting the code snippet below into `src/ClimaCalibrate.jl`.
-This will precompile the model step and all callbacks for the given configuration.
+
+The easiest way is by copying and pasting the code snippet below into
+`src/ClimaCalibrate.jl`. This will precompile the model step and all callbacks
+for the given configuration.
+
 ```julia
 using PrecompileTools
 import SciMLBase

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,48 +1,157 @@
 # Getting Started
 
+!!! note "Preliminaries"
+    You may find it helpful to read the [documentation](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/)
+    of EnsembleKalmanProcesses.jl before reading this section.
+
 Every calibration requires
-- a forward model, which uses input parameters to return diagnostic output
 - observational data, which can be a Vector or an
   [`EnsembleKalmanProcess.Observation`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/Observations/#EnsembleKalmanProcesses.Observation)
 - a prior parameter distribution. The easiest way to construct a distribution is
   with the [`EnsembleKalmanProcess.constrained_gaussian`](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/ParameterDistributions/#EnsembleKalmanProcesses.ParameterDistributions.constrained_gaussian)
-  function.
+  function,
+- a forward model, which uses input parameters to return diagnostic output
+- an observation map, which maps the forward model's diagnostic output to a
+  vector comparable to the observations
 
 ## Implementing your experiment
 
-### Forward Model
+All [`calibrate`](@ref) functions require a backend, an
+`EnsembleKalmanProcesses.EnsembleKalmanProcess` object, and a model interface.
+This tutorial will not go into details on how to construct the
+`EnsembleKalmanProcess` object. Please refer to the
+[docs](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/) instead.
 
-Your forward model must implement the [`forward_model(iteration, member)`](@ref)
-function stub.
+### Backend system
 
-Since this function only takes in the iteration and member numbers, there are some
-hooks to obtain parameters and the output directory:
+!!! note "Backends"
+    For more information about the backend system, refer to the documentation
+    [here](@ref Backends).
 
-- [`ClimaCalibrate.Calibration.path_to_ensemble_member`](@ref) returns the ensemble member's output directory,
+There are three different kind of backends which are [`JuliaBackend`](@ref),
+[`WorkerBackend`](@ref), and the HPC cluster backends.
 
-which can be used to set the forward model's output directory.
-- [`ClimaCalibrate.Calibration.parameter_path`](@ref) returns the ensemble member's parameter file, which can
-be loaded in via TOML or passed to ClimaParams.
+The [`JuliaBackend`](@ref) is the simplest backend. The work done by each
+ensemble member is done sequentially.
 
-### Observational data
+```@example backend
+import ClimaCalibrate
 
-Observational data generally consists of a vector of observations with length `d`
- and the covariance matrix of the observational noise with size `d × d`.
+backend = ClimaCalibrate.JuliaBackend()
+nothing # hide
+```
 
-If you need to stack or sample from observations, EnsembleKalmanProcesses.jl's
-[Observation](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/Observations/#Observation)
-or [ObservationSeries](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/Observations/#ObservationSeries) are fully-featured.
-
-An **observation map** to process model output and return the full ensemble's observations is also required.
-
-This is provided by implementing the function stub [`observation_map(iteration)`](@ref). This function needs to return an `Array arr` where `arr[:, i]` will return the i-th ensemble member's observational output.
-
-Here is a readable template for the `observation_map`
+Next, the [`WorkerBackend`](@ref) is a backend compatible with Distributed.jl.
+The work done by each ensemble member is done in parallel on different
+processes. This backend is compatible with the Slurm and PBS job schedulers. It
+requires starting a job with the resources necessary to start the worker
+processes. In the example below, worker processes are being launched by
+`addprocs` on a HPC cluster that supports Slurm. You would pass `backend` to
+the [`calibrate`](@ref) function.
 
 ```julia
-function observation_map(iteration)
-    single_observation_dims = 1
-    G_ensemble = Array{Float64}(undef, single_observation_dims..., ensemble_size)
+import ClimaCalibrate
+import Distributed
+
+Distributed.addprocs(ClimaCalibrate.SlurmManager())
+backend = ClimaCalibrate.WorkerBackend()
+```
+
+Finally, the [`HPCBackend`](@ref) is a backend specfic to each HPC cluster. The
+work done by each ensemble member is done in parallel on different jobs. In the
+example, each job would start with the `directives`, `modules`, and `env_vars`
+listed. The job would last for 720 minutes with single task of 12 CPUs and 1
+GPU with regular job priority. The `climacommon` module will be loaded when the
+job starts and the environment variables for ClimaComms will be set.
+
+```@example backend
+import ClimaCalibrate
+
+backend = ClimaCalibrate.DerechoBackend(;
+    directives = [
+        :job_priority => "regular",
+        :time => 720,
+        :ntasks => 1,
+        :cpus_per_task => 12,
+        :gpus_per_task => 1,
+    ],
+    modules = ["climacommon"],
+    env_vars = ["CLIMACOMMS_CONTEXT" => "SINGLETON", "CLIMACOMMS_DEVICE" => "CUDA"],
+)
+nothing # hide
+```
+
+### Model interface
+
+ClimaCalibrate provides the abstract type [`AbstractModelInterface`](@ref). For
+calibration, you will create a struct that will subtype this type and implements
+the required interface for this function to work.
+
+The necessary functions are
+- `forward_model(interface, iteration, member)` which runs the forward model for
+  a single ensemble member.
+- `observation_map(interface, iteration)` which processes model output and
+  returns a matrix of outputs where each column is the forward model output.
+  This matrix is called the `G_ensemble` matrix.
+
+If you want to calibrate using one of the `HPCBackend`s, you also need to
+implement
+- `model_interface_filepath(interface)` which returns the path to the file that
+  defines the model interface.
+
+#### Forward Model
+
+Your forward model must implement the
+[`forward_model(interface, iteration, member)`](@ref) function stub.
+
+Since this function only takes in the iteration and member numbers, there are
+some hooks to obtain parameters and the output directory:
+
+- [`ClimaCalibrate.Calibration.path_to_ensemble_member`](@ref) returns the
+  ensemble member's output directory,
+
+which can be used to set the forward model's output directory.
+
+- [`ClimaCalibrate.Calibration.parameter_path`](@ref) returns the ensemble
+member's parameter file, which can be loaded in via TOML or passed to
+ClimaParams.
+
+#### Observation map
+
+!!! note "Observational data"
+    Observational data generally consists of a vector of observations with
+    length `d` and the covariance matrix of the observational noise with size
+    `d × d`.
+
+    If you need to stack or sample from observations,
+    EnsembleKalmanProcesses.jl's
+    [Observation](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/Observations/#Observation) or
+    [ObservationSeries](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/Observations/#ObservationSeries) are fully-featured.
+
+    For preprocessing observational data, you want to preprocess for `NaN`s
+    and regrid and convert units to match the simulation data and vice versa.
+
+    If you are using `ClimaAnalysis` to preprocess the observational data, then
+    you may want to use [`ObservationRecipe`](@ref) to create
+    observations from `OutputVar`s.
+
+An **observation map** to process model output and return the full ensemble's
+observations is also required.
+
+This is provided by implementing the function stub
+[`observation_map(interface, iteration)`](@ref). This function needs to return
+an `Matrix` where the `i`th column is the `i`th ensemble member's observational
+output. This matrix is called the G ensemble matrix.
+
+Here is a simple readable template for the `observation_map`
+
+```julia
+function ClimaCalibrate.observation_map(interface, iteration)
+    # This assumes the output_dir is a field of interface
+    (; output_dir) = interface
+    ekp = JLD2.load_object(ClimaCalibrate.ekp_path(output_dir, iteration))
+    ensemble_size = EKP.get_N_ens(ekp)
+    G_ensemble = ClimaCalibrate.g_ens_matrix(ekp)
     for member in 1:ensemble_size
         G_ensemble[:, member] = process_member_data(iteration, member)
     end
@@ -50,25 +159,45 @@ function observation_map(iteration)
 end
 ```
 
-### Optional postprocessing
+Note that each column of the G ensemble matrix should match with the
+observations. A common source of error is that the ordering of the variables in
+the observations is not the same as the ordering of the variables for the
+columns of the G ensemble matrix.
 
-It may be the case that `observation_map` is insufficient as you need to more information,
-such as information from the `ekp` object to compute `G_ensemble`. Further postprocessing of the
-`G_ensemble` object can be done by implementing the `postprocess_g_ensemble` as shown
-below.
+!!! note "GEnsembleBuilder"
+    If you are using `ObservationRecipe` to construct your observations and are
+    using ClimaAnalysis to postprocess your simulation output, then you might
+    want to use [`GEnsembleBuilder`](@ref) which simplifies the construction of the
+    G ensemble matrix.
+
+#### Optional postprocessing
+
+It may be the case that `observation_map` is insufficient as you need more
+information, such as information from the `ekp` object to compute `G_ensemble`.
+Further postprocessing of the `G_ensemble` object can be done by implementing
+the `postprocess_g_ensemble` as shown below.
 
 ```julia
-function postprocess_g_ensemble(ekp, g_ensemble, prior, output_dir, iteration)
+function ClimaCalibrate.postprocess_g_ensemble(
+    interface,
+    ekp,
+    g_ensemble,
+    prior,
+    output_dir,
+    iteration
+)
     return g_ensemble
 end
 ```
 
-After each evaluation of the observation map and before updating the ensemble, it may be
-helpful to print the errors from the `ekp` object or plot `G_ensemble`. This can be done
-by implementing the `analyze_iteration` as shown below.
+After each evaluation of the observation map and before updating the ensemble,
+it may be helpful to print the errors from the `ekp` object or plot
+`G_ensemble`. This can be done by implementing the `analyze_iteration` as shown
+below.
 
 ```julia
 function ClimaCalibrate.analyze_iteration(
+    interface,
     ekp,
     g_ensemble,
     prior,
@@ -88,17 +217,23 @@ end
 
 Every parameter that is being calibrated requires a prior distribution to sample from.
 
-EnsembleKalmanProcesses.jl's [constrained_gaussian](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/ParameterDistributions/#EnsembleKalmanProcesses.ParameterDistributions.constrained_gaussian) 
+EnsembleKalmanProcesses.jl's
+[constrained_gaussian](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/API/ParameterDistributions/#EnsembleKalmanProcesses.ParameterDistributions.constrained_gaussian)
 provides a user-friendly way to constructor Gaussian distributions.
 
-Multiple distributions can be combined using `combine_distributions(vec_of_distributions)`.
+Multiple distributions can be combined using
+`combine_distributions(vec_of_distributions)`.
 
-For more information, see the EKP documentation for [prior distributions](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/).
+For more information, see the EKP documentation for
+[prior distributions](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/).
 
 ### Experiment Configuration
-A calibration consisting of `m` ensemble members will run for `n` iterations.
 
-A good rule of thumb is an ensemble size 10 times the number of parameters.
+A calibration consisting of `m` ensemble members that will run for `n`
+iterations. The recommended ensemble size is a function of the chosen method and
+the number of parameters being calibrated. See the
+[EnsembleKalmanProcesses.jl documentation](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/defaults/#ens-size)
+for more information for choosing the appropriate ensemble size.
 
 ### Calibrate
 
@@ -111,69 +246,156 @@ Now all of the pieces should be in place:
 - ensemble size
 - number of iterations
 
-And we can put it all together:
-
-`calibrate(ensemble_size, n_iterations, observations, noise, prior, output_dir)`
-
-Lastly, you need to set the output directory, ensemble size and the number of iterations to run for. A good rule of thumb for your ensemble size is 10x the number of free parameters.
+Lastly, you need to set the output directory and the number of
+iterations to run for.
 
 ```julia
 n_iterations = 7
-ensemble_size = 10
 output_dir = "output/my_experiment"
 ```
-Once all of this has been set up, you can call put it all together using the [`calibrate`](@ref) function:
+Once all of this has been set up, you can call put it all together using the
+[`calibrate`](@ref) function:
 
 ```julia
-calibrate(ensemble_size, n_iterations, observations, noise, prior, output_dir)
+# Construct the EnsembleKalmanProcess object as ekp
+ClimaCalibrate.calibrate(
+    backend,
+    ekp,
+    interface,
+    n_iterations,
+    prior,
+    output_dir,
+)
 ```
 
-For more information on parallelizing your calibration, see the [Backends](https://clima.github.io/ClimaCalibrate.jl/dev/backends/) page.
+For more information on parallelizing your calibration, see the
+[Backends](@ref Backends) page.
+
+### File structure
+
+For a calibration that ran for a single iteration, the calibration output directory
+might look like this.
+
+```
+.
+├── iteration_001
+│   ├── eki_file.jld2
+│   ├── G_ensemble.jld2
+│   ├── member_001
+│   │   ├── checkpoint.txt
+│   │   └── parameters.toml
+│   ├── member_002
+│   │   ├── checkpoint.txt
+│   │   └── parameters.toml
+│   ├── member_003
+│   │   ├── checkpoint.txt
+│   │   └── parameters.toml
+│   └── prior.jld2
+└── iteration_002
+    ├── eki_file.jld2
+    ├── member_001
+    │   └── parameters.toml
+    ├── member_002
+    │   └── parameters.toml
+    └── member_003
+        └── parameters.toml
+```
+
+Each file in the output directory serves a specific purpose:
+
+- `eki_file.jld2`: The serialized `EnsembleKalmanProcess` state saved **before**
+  the iteration runs. For example, `iteration_001/eki_file.jld2` holds the state
+  used to generate the parameters for iteration 1.
+- `parameters.toml`: Each member's sampled parameter values, written before the
+  forward model runs. Load this via TOML or pass it to ClimaParams in your
+  `forward_model`.
+- `G_ensemble.jld2`: The G ensemble matrix produced by the observation map
+  **after** all forward models in the iteration complete.
+- `checkpoint.txt`: A flag file written when a member's forward model completes
+  successfully, used to skip completed members on restart.
+- `prior.jld2`: The prior distribution, saved once in `iteration_001`.
+
+The JLD2 files can be loaded using
+[`JLD2`](https://juliaio.github.io/JLD2.jl/stable/).
+
+To access these paths programmatically:
+- [`ekp_path(output_dir, iteration)`](@ref): Path to `eki_file.jld2` for the
+  given iteration.
+- [`parameter_path(output_dir, iteration, member)`](@ref): Path to an ensemble
+  member's `parameters.toml`.
+- [`path_to_ensemble_member(output_dir, iteration, member)`](@ref): Path to an
+  ensemble member's output directory.
+- [`path_to_iteration(output_dir, iteration)`](@ref): Path to an iteration's
+  directory.
 
 # Checkpointing
 
-ClimaCalibrate checkpoints each forward model and iteration so that an interrupted
-calibration can seamlessly pick up where it left off without wasting resources.
+ClimaCalibrate checkpoints each forward model and iteration so that an
+interrupted calibration can seamlessly pick up where it left off without wasting
+resources.
 
-If a calibration (run via `calibrate`) exits after completing an iteration, 
-when it is restarted it will automatically run the next iteration. 
-This is done by checking if the ensemble forward map results file (`G_ensemble.jld2`) 
-and the EKI file (`eki_file.jld2`) have been saved.
+If a calibration (run via `calibrate`) exits after completing an iteration, when
+it is restarted it will automatically run the next iteration. This is done by
+checking if the ensemble forward map results file (`G_ensemble.jld2`) and the
+EKI file (`eki_file.jld2`) have been saved.
 
-If a calibration is interrupted during forward model execution, 
-causing a partial iteration, incomplete forward models will be rerun when the 
-calibration is restarted. Completed forward models will not be rerun.
-This is done by checking each model's checkpoint file and the flag it contains.
+If a calibration is interrupted during forward model execution, causing a
+partial iteration, incomplete forward models will be rerun when the calibration
+is restarted. Completed forward models will not be rerun. This is done by
+checking each model's checkpoint file and the flag it contains.
+
+!!! note "Forward model restarts"
+    Although the model is checkpointed, this does not mean the forward model
+    will automatically restarts. This functionality is delegated to forward
+    model.
 
 # Example Calibrations
 
 The [example tutorial](https://clima.github.io/ClimaCalibrate.jl/dev/literate_example/)
-provides a clear calibration example that can be run locally.
+provides a clear calibration example that can be run locally using the
+[`WorkerBackend`](@ref).
 
-Another example experiment can be found in the package repo under `experiments/surface_fluxes_perfect_model`.
-This experiment uses the [SurfaceFluxes.jl](https://github.com/CliMA/SurfaceFluxes.jl) package 
-to generate a physical model that calculates the Monin Obukhov turbulent surface 
-fluxes based on idealized atmospheric and surface conditions. Since this is a "perfect 
-model" example, the same model is used to generate synthetic observations using its 
-default parameters and a small amount of noise. These synthetic observations are 
-considered to be the ground truth, which is used to assess the model ensembles' 
-performance when parameters are drawn from the prior parameter distributions. 
+Another example experiment can be found in the package repo under
+`experiments/surface_fluxes_perfect_model`.
+This experiment uses the
+[SurfaceFluxes.jl](https://github.com/CliMA/SurfaceFluxes.jl) package to
+generate a physical model that calculates the Monin Obukhov turbulent surface
+fluxes based on idealized atmospheric and surface conditions. Since this is a
+"perfect model" example, the same model is used to generate synthetic
+observations using its default parameters and a small amount of noise. These
+synthetic observations are considered to be the ground truth, which is used to
+assess the model ensembles' performance when parameters are drawn from the prior
+parameter distributions.
 
-It is a perfect-model calibration, using its own output as observational data. 
-By default, it runs 20 ensemble members for 8 iterations. 
-This example can be run on the most common backend, the WorkerBackend, with the following script:
+It is a perfect-model calibration, using its own output as observational data.
+By default, it runs 20 ensemble members for 8 iterations. This example can be
+run on the most common backend, the [`JuliaBackend`](@ref), with the following
+script:
 
 ```julia
-using ClimaCalibrate
+import ClimaCalibrate
+import EnsembleKalmanProcesses as EKP
 
 include(joinpath(pkgdir(ClimaCalibrate), "experiments", "surface_fluxes_perfect_model", "utils.jl"))
 @show ensemble_size n_iterations observation variance prior
 
-eki = calibrate(
-    ensemble_size,
-    n_iterations,
+# Construct the initial ensemble and EKP object
+initial_ensemble = EKP.construct_initial_ensemble(prior, ensemble_size)
+ekp = EKP.EnsembleKalmanProcess(
+    initial_ensemble,
     observation,
     variance,
+    EKP.Inversion(),
+    EKP.default_options_dict(EKP.Inversion()),
+)
+
+output_dir = "my_experiment"
+mkpath(output_dir)
+eki = ClimaCalibrate.calibrate(
+    JuliaBackend(),
+    ekp,
+    SurfaceFluxModelInterface(),
+    n_iterations,
     prior,
     output_dir,
 )

--- a/docs/src/submit_scripts.md
+++ b/docs/src/submit_scripts.md
@@ -1,20 +1,28 @@
 # Job Submission Scripts for HPC Clusters
 
-This page provides concrete examples and best practices for running calibrations on HPC clusters using ClimaCalibrate.jl. The examples assume basic familiarity with either Slurm or PBS job schedulers.
+This page provides concrete examples and best practices for running calibrations
+on HPC clusters using ClimaCalibrate.jl. The examples assume basic familiarity
+with either Slurm or PBS job schedulers.
 
 ## Overview
 
-ClimaCalibrate.jl supports two main approaches for running calibrations on HPC clusters:
+ClimaCalibrate.jl supports two main approaches for running calibrations on HPC
+clusters:
 
-1. **WorkerBackend**: Uses Julia's distributed computing capabilities with workers managed by the job scheduler
-2. **HPC Backends**: Directly submits individual model runs as separate jobs to the scheduler
+1. **WorkerBackend**: Uses Julia's distributed computing capabilities
+   with workers managed by the job scheduler
+2. **HPCBackends**: Directly submits individual model runs as
+   separate jobs to the scheduler
 
-The choice between these approaches depends on your cluster's resource allocation policies and your model's computational requirements.
-For more information, see the Backends page.
+The choice between these approaches depends on your cluster's resource
+allocation policies and your model's computational requirements. For more
+information, see the [Backends](@ref Backends) page.
 
 ## WorkerBackend on a Slurm cluster
 
-When using `WorkerBackend` on a Slurm cluster, allocate resources at the top level since Slurm allows nested resource allocations. Each worker will inherit one task from the Slurm allocation.
+When using [`WorkerBackend`](@ref) on a Slurm cluster, allocate resources at the
+top level since Slurm allows nested resource allocations. Each worker will
+inherit one task from the Slurm allocation.
 
 ```bash
 #!/bin/bash
@@ -39,14 +47,18 @@ julia --project=calibration calibration_script.jl
 ```
 
 **Key points:**
-- `--ntasks=5`: Requests 5 tasks, each worker gets one task
+- `--ntasks=5`: Requests 5 tasks, each worker gets one task.
 - `--cpus-per-task=4`: Each worker gets 4 CPU cores
 - `--gpus-per-task=1`: Each worker gets 1 GPU
 - Uses `%j` in output/error file names to interpolate the job ID
+- It is recommended to use the same number of tasks as ensemble members to
+  parallelize the work across all ensemble members.
 
 ## WorkerBackend on a PBS cluster
 
-Since PBS does not support nested resource allocations, request minimal resources for the top-level script. Each worker will acquire its own resource allocation through the `PBSManager`.
+Since PBS does not support nested resource allocations, request minimal
+resources for the top-level script. Each worker will acquire its own resource
+allocation through the [`PBSManager`](@ref).
 
 ```bash
 #!/bin/bash
@@ -72,18 +84,22 @@ julia --project=calibration calibration_script.jl
 
 **Key points:**
 - Requests only 1 CPU core for the main script
-- Workers will be launched as separate PBS jobs with their own resource allocations
+- Workers will be launched as separate PBS jobs with their own resource
+  allocations
 - Uses `${PBS_JOBID}` to include the job ID in output file names
 
 ## HPC Backend Approach
 
-HPC backends directly submit individual forward model runs as separate jobs to the scheduler. This approach is ideal when:
+The [`HPCBackend`](@ref)s directly submit individual forward model runs as
+separate jobs to the scheduler. This approach is ideal when:
 - Your forward model requires multiple CPU cores or GPUs
 - You need fine-grained control over resource allocation per model run
 - Your cluster doesn't support nested allocations
 
-Since each model run consists of an independent resource allocation, minimal resources are needed to run the top-level calibration script.
-For a slurm cluster, here is a minimal submission script:
+Since each model run consists of an independent resource allocation, minimal
+resources are needed to run the top-level calibration script. For a Slurm
+cluster, here is a minimal submission script:
+
 ```bash
 #!/bin/bash
 #SBATCH --job-name=slurm_calibration
@@ -99,66 +115,84 @@ module load climacommon
 julia --project=calibration -e 'using Pkg; Pkg.instantiate(;verbose=true)'
 julia --project=calibration calibration_script.jl
 ```
-For a PBS cluster, the script in the WorkerBackend section can be reused since it already specifies a minimal resource allocation.
+For a PBS cluster, the script in the [`WorkerBackend`](@ref) section can be
+reused since it already specifies a minimal resource allocation.
 
 ## Resource Configuration
 
-### CPU-Only Jobs
+Configurations of the jobs submitted by the HPC backends are set by the
+[`SlurmConfig`](@ref) for clusters using Slurm or [`PBSConfig`](@ref) for
+clusters using PBS.
 
-For CPU-only forward models:
-
-```julia
-hpc_kwargs = Dict(
-    :time => 30,
-    :ntasks => 1,
-    :cpus_per_task => 8,
-    :mem => "16G"
-)
+```@setup config
+import ClimaCalibrate
 ```
 
-### GPU Jobs
-
-For GPU-accelerated forward models:
-
-```julia
-hpc_kwargs = Dict(
-    :time => 60,
-    :ntasks => 1,
-    :cpus_per_task => 4,
-    :gpus_per_task => 1,
-    :mem => "32G"
+```@example config
+ClimaCalibrate.SlurmConfig(;
+    directives = [
+        :ntasks => 1,
+        :gpus_per_task => 1,
+        :cpus_per_task => 12,
+        :time => 720,
+    ],
+    modules = ["climacommon"],
+    env_vars = [
+        "CLIMACOMMS_CONTEXT" => "SINGLETON",
+        "CLIMACOMMS_DEVICE" => "CUDA",
+    ],
 )
+
+nothing # hide
 ```
 
-### Multi-Node Jobs
+This example creates a Slurm configuration for a job with a single task, using
+12 CPUs and 1 GPU, and a runtime of 720 minutes. It loads the latest version of
+climacommon and explicitly sets environment variables for ClimaComms. The same
+keyword arguments can also be passed to the `PBSConfig`.
 
-For models requiring multiple nodes:
+!!! note "Backend constructors"
+    To simplify the process of constructing a backend, you can pass
+    `directives`, `modules`, and `env_vars` as keyword arguments to the backend
+    constructor.
 
-```julia
-hpc_kwargs = Dict(
-    :time => 120,
-    :ntasks => 16,
-    :cpus_per_task => 4,
-    :nodes => 4,
-    :mem => "64G"
-)
-```
+    ```@example config
+    ClimaCalibrate.ClimaGPUBackend(;
+         directives = [
+            :ntasks => 1,
+            :gpus_per_task => 1,
+            :cpus_per_task => 12,
+            :time => 720,
+         ],
+         modules = ["climacommon"],
+         env_vars = [
+            "CLIMACOMMS_CONTEXT" => "SINGLETON",
+            "CLIMACOMMS_DEVICE" => "CUDA",
+         ],
+    )
+
+    nothing # hide
+    ```
 
 ## Environment Variables
 
 Set these environment variables in your submission script:
 
 - `CLIMACOMMS_DEVICE`: Set to `"CUDA"` for GPU runs or `"CPU"` for CPU-only runs
-- `CLIMACOMMS_CONTEXT`: Set to `"SINGLETON"` for WorkerBackend. The context is automatically set to `"MPI"` for HPC backends
+- `CLIMACOMMS_CONTEXT`: Set to `"SINGLETON"` for [`WorkerBackend`](@ref). The
+  context is automatically set to `"MPI"` for HPC backends.
 
 ## Troubleshooting
 
 ### Common Issues
 
-1. **Worker Timeout**: Increase `ENV["JULIA_WORKER_TIMEOUT"]` in your Julia session if workers are timing out
-2. **Memory Issues**: Monitor memory usage and adjust `--mem` or `-l mem` accordingly.
+1. **Worker Timeout**: Increase `ENV["JULIA_WORKER_TIMEOUT"]` in your Julia
+   session if workers are timing out
+2. **Memory Issues**: Monitor memory usage and adjust `--mem` or `-l mem`
+   accordingly.
 3. **GPU Allocation**: Ensure `--gpus-per-task` or `-l select` is set correctly
-4. **Module Conflicts**: Use `module purge` and ensure your MODULEPATH is set before loading required modules
+4. **Module Conflicts**: Use `module purge` and ensure your MODULEPATH is set
+   before loading required modules
 
 ### Debugging Commands
 

--- a/ext/ClimaCalibrateClimaAnalysisExt.jl
+++ b/ext/ClimaCalibrateClimaAnalysisExt.jl
@@ -1,4 +1,4 @@
-module ClimaAnalysisExt
+module ClimaCalibrateClimaAnalysisExt
 
 import ClimaAnalysis
 import ClimaAnalysis: OutputVar

--- a/ext/ensemble_builder.jl
+++ b/ext/ensemble_builder.jl
@@ -67,26 +67,26 @@ function EnsembleBuilder.GEnsembleBuilder(
 ) where {FT <: AbstractFloat}
     obs_series = EKP.get_observation_series(ekp)
     N = EKP.get_N_iterations(ekp) + 1
-    metadatas = ClimaCalibrate.get_metadata_for_nth_iteration(obs_series, N)
+    metadata = ClimaCalibrate.get_metadata_for_nth_iteration(obs_series, N)
 
     # It is a little wasteful to allocate the data here, but it is easier to
     # index if it is a single vector
     obs = ClimaCalibrate.get_observations_for_nth_iteration(obs_series, N)
     stacked_obs = mapreduce(EKP.get_obs, vcat, obs)
 
-    eltype(metadatas) <: ClimaAnalysis.Var.Metadata || error(
+    all(m isa ClimaAnalysis.Var.Metadata for m in metadata) || error(
         "GEnsembleBuilder is only compatible with metadata from ClimaAnalysis",
     )
 
     # Check all metadata contain a short name
     metadata_short_names =
-        collect(ClimaAnalysis.short_name(metadata) for metadata in metadatas)
+        collect(ClimaAnalysis.short_name(m) for m in metadata)
     any(==(""), metadata_short_names) && error(
         "One of the observations does not has a short name; add a short name to the OutputVar before making an observation from it",
     )
 
     G_ens = g_ens_matrix(ekp)
-    completed = falses(length(metadatas), EKP.get_N_ens(ekp))
+    completed = falses(length(metadata), EKP.get_N_ens(ekp))
 
     short_name_to_metadata_map = Dict{String, Vector{MetadataInfo}}()
     minibatch_indices =
@@ -99,11 +99,11 @@ function EnsembleBuilder.GEnsembleBuilder(
     @assert first(size(G_ens)) == last(last(minibatch_indices))
 
     all_metadata_vec = MetadataInfo[]
-    for (i, (metadata, range)) in enumerate(zip(metadatas, minibatch_indices))
-        short_name = ClimaAnalysis.short_name(metadata)
+    for (i, (m, range)) in enumerate(zip(metadata, minibatch_indices))
+        short_name = ClimaAnalysis.short_name(m)
         metadata_with_short_name_vec =
             get!(short_name_to_metadata_map, short_name, MetadataInfo[])
-        metadata_info = MetadataInfo(i, range, metadata)
+        metadata_info = MetadataInfo(i, range, m)
         push!(metadata_with_short_name_vec, metadata_info)
         push!(all_metadata_vec, metadata_info)
     end

--- a/ext/ensemble_builder.jl
+++ b/ext/ensemble_builder.jl
@@ -339,11 +339,13 @@ end
 
 Return the G ensemble matrix from `g_ens_builder`.
 
-This function does not check that the G ensemble matrix is completed. See
+If the G ensemble matrix is not completed, then a warning is thrown. See
 [`ClimaCalibrate.EnsembleBuilder.is_complete`](@ref) to check if the G ensemble
 matrix is completely filled out.
 """
 function EnsembleBuilder.get_g_ensemble(g_ens_builder::GEnsembleBuilder)
+    EnsembleBuilder.is_complete(g_ens_builder) ||
+        "G ensemble matrix is not completed. Check the OutputVars passed to the G ensemble builder. You may find it useful to call `EnsembleBuilder.missing_short_names(g_ens_builder, 1) or display the GEnsembleBuilder object in the REPL"
     return g_ens_builder.g_ens
 end
 

--- a/ext/ensemble_builder.jl
+++ b/ext/ensemble_builder.jl
@@ -345,7 +345,7 @@ matrix is completely filled out.
 """
 function EnsembleBuilder.get_g_ensemble(g_ens_builder::GEnsembleBuilder)
     EnsembleBuilder.is_complete(g_ens_builder) ||
-        "G ensemble matrix is not completed. Check the OutputVars passed to the G ensemble builder. You may find it useful to call `EnsembleBuilder.missing_short_names(g_ens_builder, 1) or display the GEnsembleBuilder object in the REPL"
+        @warn "G ensemble matrix is not completed. Check the OutputVars passed to the G ensemble builder. You may find it useful to call `EnsembleBuilder.missing_short_names(g_ens_builder, 1)` or display the GEnsembleBuilder object in the REPL"
     return g_ens_builder.g_ens
 end
 

--- a/ext/observation_recipe.jl
+++ b/ext/observation_recipe.jl
@@ -460,15 +460,13 @@ If the short name is not available, then `nothing` is returned instead.
 function ObservationRecipe.short_names(obs::EKP.Observation)
     # Get the short names from the metadata rather than the name of the
     # observation, because the name can be changed by the user
-    metadatas = EKP.get_metadata(obs)
-    eltype(metadatas) <: ClimaAnalysis.Var.Metadata || error(
+    metadata = EKP.get_metadata(obs)
+    all(m isa ClimaAnalysis.Var.Metadata for m in metadata) || error(
         "Getting the short names from an observation is only supported with metadata from ClimaAnalysis",
     )
 
-    short_names = collect(
-        get(metadata.attributes, "short_name", nothing) for
-        metadata in metadatas
-    )
+    short_names =
+        collect(get(m.attributes, "short_name", nothing) for m in metadata)
     return short_names
 end
 
@@ -688,18 +686,19 @@ function ObservationRecipe.reconstruct_g_mean_final(
     ekp::EKP.EnsembleKalmanProcess,
 )
     obs_series = EKP.get_observation_series(ekp)
-    metadatas = ClimaCalibrate.get_metadata_for_nth_iteration(
+    metadata = ClimaCalibrate.get_metadata_for_nth_iteration(
         obs_series,
         EKP.get_N_iterations(ekp),
     )
-    eltype(metadatas) <: ClimaAnalysis.Var.Metadata || error(
+    all(m isa ClimaAnalysis.Var.Metadata for m in metadata) || error(
         "Getting the short names from an observation is only supported with metadata from ClimaAnalysis",
     )
+
     g_mean = EKP.get_g_mean_final(ekp)
 
     # Check if length of g ensemble is the same as the length of the data in the metadatas
     total_metadata_length =
-        sum(ClimaAnalysis.flattened_length(metadata) for metadata in metadatas)
+        sum(ClimaAnalysis.flattened_length(m) for m in metadata)
     length(g_mean) != total_metadata_length && error(
         "Length of g_mean_final is not the same as the length of all the metadata",
     )
@@ -710,8 +709,8 @@ function ObservationRecipe.reconstruct_g_mean_final(
             obs_series,
             EKP.get_N_iterations(ekp),
         )
-    vars = map(metadatas, minibatch_indices) do metadata, range
-        ClimaAnalysis.unflatten(metadata, g_mean[range])
+    vars = map(metadata, minibatch_indices) do m, range
+        ClimaAnalysis.unflatten(m, g_mean[range])
     end
     return vars
 end

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -19,6 +19,8 @@ export initialize,
     parameter_path,
     checkpoint_path,
     load_latest_ekp,
+    load_ekp_struct,
+    ekp_path,
     save_eki_and_parameters,
     model_started,
     model_completed,
@@ -149,7 +151,6 @@ Saves the ensemble's observation map output to the correct directory based on th
 Takes an output directory, iteration number, and the ensemble output to save.
 """
 function save_G_ensemble(output_dir::AbstractString, iteration, G_ensemble)
-    iter_path = path_to_iteration(output_dir, iteration)
     JLD2.save_object(path_to_G_ensemble(output_dir, iteration), G_ensemble)
     return G_ensemble
 end
@@ -217,7 +218,6 @@ end
 Updates the EnsembleKalmanProcess object and saves the parameters for the next iteration.
 """
 function update_ensemble(output_dir::AbstractString, iteration, prior)
-    iter_path = path_to_iteration(output_dir, iteration)
     G_ens = JLD2.load_object(path_to_G_ensemble(output_dir, iteration))
 
     ekp = load_ekp_struct(output_dir, iteration)

--- a/src/ekp_utils.jl
+++ b/src/ekp_utils.jl
@@ -70,7 +70,7 @@ end
 """
     g_ens_matrix(eki::EKP.EnsembleKalmanProcess{FT}) where {FT <: AbstractFloat}
 
-Construct an uninitialized G ensemble matrix of type `FT` for the current
+Construct an G ensemble matrix of type `FT` with all `NaN`s for the current
 iteration.
 """
 function g_ens_matrix(
@@ -79,7 +79,9 @@ function g_ens_matrix(
     obs = EKP.get_obs(eki)
     single_obs_len = sum(length(obs))
     ensemble_size = EKP.get_N_ens(eki)
-    return Array{FT}(undef, single_obs_len, ensemble_size)
+    g_ens_matrix = Array{FT}(undef, single_obs_len, ensemble_size)
+    fill!(g_ens_matrix, NaN)
+    return g_ens_matrix
 end
 
 """

--- a/src/model_interface.jl
+++ b/src/model_interface.jl
@@ -24,7 +24,7 @@ dispatch the calibration interface functions.
 Subtypes must implement:
 - `forward_model(interface, iteration, member)` which runs the forward model for a
   single ensemble member.
-- `observation_map(interface, iteration)` which processes model output and,
+- `observation_map(interface, iteration)` which processes model output and
   returns a `G_ensemble` matrix.
 
 To use the `HPCBackend`, the subtypes must also implement:

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -17,7 +17,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
 # Since functions not defined in ext are not exported, we need to access
 # them like this
-ext = Base.get_extension(ClimaCalibrate, :ClimaAnalysisExt)
+ext = Base.get_extension(ClimaCalibrate, :ClimaCalibrateClimaAnalysisExt)
 
 import ClimaAnalysis.Template:
     TemplateVar,

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -15,7 +15,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
 # Since functions not defined in ext.jl are not exported, we need to access
 # them like this
-ext = Base.get_extension(ClimaCalibrate, :ClimaAnalysisExt)
+ext = Base.get_extension(ClimaCalibrate, :ClimaCalibrateClimaAnalysisExt)
 
 import ClimaAnalysis.Template:
     TemplateVar,


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCalibrate.jl/issues/313, closes https://github.com/CliMA/ClimaCalibrate.jl/issues/311, closes https://github.com/CliMA/ClimaCalibrate.jl/issues/309

This PR fixes issues that were encountered when updating the calibration pipelines to use the main branch. For example, `ekp_path` should have been exported, but was not. Another example is that `project_dir` was missing a qualifier in the calibration function. In addition, the docs were stale which this PR help clean up.


TODO

- [x] Update NEWS.md
- [x] First merge https://github.com/CliMA/ClimaCalibrate.jl/pull/312