### PR TITLE
Set GPU rank for PBS jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ ClimaCalibrate.jl Release Notes
 main
 -------
 
+v0.3.1
+-------
+
 - Add `dims` keyword argument to observation and covariance constructors in
   the `ObservationRecipe` module [#318](https://github.com/CliMA/ClimaCalibrate.jl/pull/318)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCalibrate"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/src/backends/pbs.jl
+++ b/src/backends/pbs.jl
@@ -26,7 +26,9 @@ function make_job_script(
 
     if gpus_per_node > 0
         ranks_per_node = gpus_per_node
-        set_gpu_rank = "set_gpu_rank"
+        # Use a bash script to set GPU ranks for each process, needed so that 
+        # MPI can properly use multiple GPUs concurrently
+        set_gpu_rank = joinpath(@__DIR__, "set_gpu_rank.sh")
     else
         ranks_per_node = cpus_per_node
         set_gpu_rank = ""
@@ -191,7 +193,8 @@ end
 
 function module_load_string(backend::DerechoBackend)
     module_loads = generate_modules(backend.hpc_config)
-    return """export MODULEPATH="/glade/campaign/univ/ucit0011/ClimaModules-Derecho:\$MODULEPATH"
-    module purge
-    $module_loads"""
+    return """module purge
+    module use /glade/campaign/univ/ucit0011/ClimaModules-Derecho
+    $module_loads
+    module list 2>&1"""
 end

--- a/src/backends/set_gpu_rank.sh
+++ b/src/backends/set_gpu_rank.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Maps MPI ranks to GPUs for ClimaCalibrate's PBS backend.
+#
+# This is adapted from NCAR Derecho's /opt/utils/bin/set_gpu_rank.
+
+case $LMOD_FAMILY_MPI in
+    cray-mpich)
+        export MPICH_GPU_SUPPORT_ENABLED=1
+        export MPICH_OFI_NIC_POLICY=GPU
+        local_rank=$PMI_LOCAL_RANK
+        local_size=$PMI_LOCAL_SIZE
+        ;;
+    openmpi)
+        local_rank=$OMPI_COMM_WORLD_LOCAL_RANK
+        local_size=$OMPI_COMM_WORLD_LOCAL_SIZE
+        ;;
+esac
+
+if [[ -n $local_rank && ${NGPUS:-0} -gt 0 ]]; then
+    if [[ $((local_size % NGPUS)) -eq 0 ]]; then
+        rank_gpu_id=$((local_rank / (local_size / NGPUS)))
+    else
+        rank_gpu_id=$((local_rank % NGPUS))
+    fi
+    export CUDA_VISIBLE_DEVICES=$rank_gpu_id
+elif [[ -z $local_rank && ${NGPUS:-0} -gt 0 ]]; then
+    # No recognized MPI library: expose all GPUs to the single process.
+    export CUDA_VISIBLE_DEVICES=$(seq 0 $((NGPUS - 1)) | paste -sd ',' -)
+fi
+
+exec "$@"

--- a/test/hpc_backend.jl
+++ b/test/hpc_backend.jl
@@ -14,6 +14,8 @@ backend = ClimaCalibrate.get_backend()
 directives = Dict{Symbol, Any}(:time => 5, :ntasks => 1, :cpus_per_task => 1)
 if backend == ClimaCalibrate.DerechoBackend
     directives[:queue] = "preempt"
+    directives[:gpus_per_task] = 1
+    directives[:cpus_per_task] = 4
 end
 
 climacommon_dict = Dict(

--- a/test/hpc_job_scripts.jl
+++ b/test/hpc_job_scripts.jl
@@ -116,7 +116,7 @@ export CLIMACOMMS_DEVICE="CUDA"
 export CLIMACOMMS_CONTEXT="MPI"
 
 cd \$PBS_O_WORKDIR
-\$MPITRAMPOLINE_MPIEXEC -n 2 -ppn 1 set_gpu_rank julia --project=$experiment_dir -e 'sleep(30)
+\$MPITRAMPOLINE_MPIEXEC -n 2 -ppn 1 $(joinpath(pkgdir(ClimaCalibrate), "src", "backends", "set_gpu_rank.sh")) julia --project=$experiment_dir -e 'sleep(30)
 '
 
 


### PR DESCRIPTION
This PR sets GPU ranks for PBS jobs via a bash script adapted from Derecho's `/opt/utils/bin/set_gpu_rank`.

We currently use the external `/opt/utils/bin/set_gpu_rank` script on Derecho to set GPU ranks.

The script hosted on Derecho runs `exec $*` at the end which word-splits and drops the quoting on the `-e` body . The call `set_gpu_rank julia --project=... -e import ClimaCalibrate; ...` gets parsed as `julia --project.. -e import ClimaCalibrate;...` so julia just evaluates `import` and errors. See [build](https://buildkite.com/clima/climacoupler-calibration/builds/11#019e5718-18ef-479c-b68d-9a3a7f6a4a4a) and error below. 

The script added here runs `exec "$@"` instead, which does not drop the quotes.
```
│ set_gpu_rank: using cray-mpich MPI library with 1 accelerators per node on 1 hosts...
│ set_gpu_rank: setting MPICH_GPU_SUPPORT_ENABLED=1, MPICH_OFI_NIC_POLICY=GPU
│ set_gpu_rank: host deg0038 / global rank 0 / local rank 0 / CUDA_VISIBLE_DEVICES 0
│ ERROR: ParseError:
│ # Error @ none:1:7
│ import
│ #     └ ── premature end of input
│ Stacktrace:
│  [1] top-level scope
│    @ none:1
│  [2] eval(m::Module, e::Any)
│    @ Core ./boot.jl:489
│  [3] exec_options(opts::Base.JLOptions)
│    @ Base ./client.jl:283
│  [4] _start()
│    @ Base ./client.jl:550
│ deg0038.hsn.de.hpc.ucar.edu: rank 0 exited with code 1
└ @ ClimaCalibrate.Calibration /glade/derecho/scratch/nefrathe/slurm-buildkite/climacoupler-calibration/11/depot/default/packages/ClimaCalibrate/7Y2sG/src/calibration.jl:317
```
