### PR TITLE
Add support for `OutputVar`s with no time dimension

### DIFF
--- a/.buildkite/derecho_pipeline.yml
+++ b/.buildkite/derecho_pipeline.yml
@@ -2,7 +2,7 @@ agents:
   queue: derecho
   modules: climacommon/2026_04_08
   pbs_q: main
-  pbs_l_select: "1:ncpus=1"
+  pbs_l_select: "1:ncpus=1:ngpus=1"
 
 env:
   OPENBLAS_NUM_THREADS: 1

--- a/docs/src/observation_recipe.md
+++ b/docs/src/observation_recipe.md
@@ -29,10 +29,10 @@ from, often limited, time series observations.
 
 ### Necessary data preprocessing
 
-The `OutputVar`s should represent **time series data of summary statistics**.
-For example, to compute seasonal averages of a `OutputVar`, one can use
-`ClimaAnalysis.average_season_across_time`, which will produce a `OutputVar`
-that can be used with either `SeasonalDiagonalCovariance` or
+In most cases, the `OutputVar`s represent **time series data of summary
+statistics**. For example, to compute seasonal averages of a `OutputVar`, one
+can use `ClimaAnalysis.average_season_across_time`, which will produce a
+`OutputVar` that can be used with either `SeasonalDiagonalCovariance` or
 `SVDplusDCovariance`.
 
 ```julia

--- a/ext/ensemble_builder.jl
+++ b/ext/ensemble_builder.jl
@@ -250,9 +250,11 @@ function _try_fill_g_ens_col_with_var!(
         data,
     ) || return false
 
-    match_dates_var = _match_dates(var, metadata)
+    if ClimaAnalysis.has_time(var) && ClimaAnalysis.has_time(metadata)
+        var = _match_dates(var, metadata)
+    end
     g_ens_builder.g_ens[range, col_idx] .=
-        ClimaAnalysis.flatten(match_dates_var, metadata).data
+        ClimaAnalysis.flatten(var, metadata).data
     if g_ens_builder.completed[index, col_idx]
         @warn(
             "This portion of the G ensemble matrix ($range, $col_idx) is already filled out by another OutputVar. Replacing the contents with the new OutputVar"

--- a/ext/observation_recipe.jl
+++ b/ext/observation_recipe.jl
@@ -443,7 +443,7 @@ function ObservationRecipe.observation(
     # Get the flattened sample and metadata
     windowed_vars =
         ClimaAnalysis.window.(vars, "time", left = start_date, right = end_date)
-    flat_vars = map(var -> ClimaAnalysis.flatten(var), windowed_vars)
+    flat_vars = map(var -> ClimaAnalysis.flatten(var; dims), windowed_vars)
     stacked_sample = vcat((flat_var.data for flat_var in flat_vars)...)
     metadata = [(flat_var.metadata for flat_var in flat_vars)...]
     covar = ObservationRecipe.covariance(

--- a/ext/observation_recipe.jl
+++ b/ext/observation_recipe.jl
@@ -28,23 +28,66 @@ function ObservationRecipe.covariance(
     end_date;
     dims = FLATTENED_DIMS,
 )
-    # Convert dates to Dates.DateTime if they are strings
-    start_date = Dates.DateTime(start_date)
-    end_date = Dates.DateTime(end_date)
+    return _covariance(covar_estimator, vars, start_date, end_date; dims)
+end
 
+"""
+    covariance(
+        covar_estimator::ScalarCovariance,
+        vars::Union{OutputVar, Iterable{OutputVar}};
+        dims = $FLATTENED_DIMS,
+    )
+
+Compute the scalar covariance matrix.
+
+Data from `vars` will not be used to compute the covariance matrix.
+"""
+function ObservationRecipe.covariance(
+    covar_estimator::ScalarCovariance,
+    vars;
+    dims = FLATTENED_DIMS,
+)
+    return _covariance(covar_estimator, vars, nothing, nothing; dims)
+end
+
+"""
+    _covariance(
+        covar_estimator::ScalarCovariance,
+        vars,
+        start_date,
+        end_date;
+        dims = FLATTENED_DIMS,
+    )
+
+Helper function for creating a scalar covariance matrix when `start_date` and
+`end_date` are either `nothing` or values convertible to `Dates.DateTime`.
+"""
+function _covariance(
+    covar_estimator::ScalarCovariance,
+    vars,
+    start_date,
+    end_date;
+    dims = FLATTENED_DIMS,
+)
     vars = _vars_to_iterable(vars)
+    dates_provided = !isnothing(start_date) && !isnothing(end_date)
+    if dates_provided
+        # Convert dates to Dates.DateTime if they are strings
+        start_date = Dates.DateTime(start_date)
+        end_date = Dates.DateTime(end_date)
 
-    for var in vars
-        _check_time_dim(var)
+        _check_time_dim_of_vars(vars, start_date, end_date)
     end
 
-    # Check if dates for start_date and end_date are in var
-    _check_dates_in_var(vars, start_date, end_date)
-
-    start_date <= end_date || error("$start_date should earlier than $end_date")
-
     diagonals = map(vars) do var
-        var = ClimaAnalysis.window(var, "time", left = start_date, right = end_date)
+        if dates_provided
+            var = ClimaAnalysis.window(
+                var,
+                "time",
+                left = start_date,
+                right = end_date,
+            )
+        end
         flattened_data = ClimaAnalysis.flatten(var; dims).data
         diag_cov = ones(eltype(flattened_data), size(flattened_data)...)
         diag_cov .*= covar_estimator.scalar
@@ -93,14 +136,7 @@ function ObservationRecipe.covariance(
 
     vars = _vars_to_iterable(vars)
 
-    for var in vars
-        _check_time_dim(var)
-    end
-
-    # Check if dates for start_date and end_date are in var
-    _check_dates_in_var(vars, start_date, end_date)
-
-    start_date <= end_date || error("$start_date should earlier than $end_date")
+    _check_time_dim_of_vars(vars, start_date, end_date)
 
     diagonals = map(vars) do var
         # Var is an OutputVar whose time slices are seasonal statistics
@@ -417,23 +453,63 @@ function ObservationRecipe.observation(
     dims = FLATTENED_DIMS,
     name = nothing,
 )
-    # Convert dates to Dates.DateTime if they are strings
-    start_date = Dates.DateTime(start_date)
-    end_date = Dates.DateTime(end_date)
+    return _observation(covar_estimator, vars, start_date, end_date; dims, name)
+end
 
-    start_date <= end_date ||
-        error("$start_date should not be later than $end_date")
+"""
+    observation(
+        covar_estimator::ScalarCovariance,
+        vars;
+        dims = FLATTENED_DIMS,
+        name = nothing
+    )
 
+Return an `EKP.Observation` with data in `vars`, a covariance matrix defined by
+`covar_estimator`, `name` determined from the short names of `vars`, and
+metadata.
+
+!!! note "Metadata"
+    Metadata in `EKP.observation` is only added with versions of
+    EnsembleKalmanProcesses later than v2.4.2.
+"""
+function ObservationRecipe.observation(
+    covar_estimator::ScalarCovariance,
+    vars;
+    dims = FLATTENED_DIMS,
+    name = nothing,
+)
+    return _observation(covar_estimator, vars, nothing, nothing; dims, name)
+end
+
+"""
+    _observation(
+        covar_estimator::AbstractCovarianceEstimator,
+        vars,
+        start_date,
+        end_date;
+        dims = FLATTENED_DIMS,
+        name = nothing,
+    )
+
+Helper function for creating an `EKP.Observation` when `start_date` and
+`end_date` are either `nothing` or values convertible to `Dates.DateTime`.
+"""
+function _observation(
+    covar_estimator::AbstractCovarianceEstimator,
+    vars,
+    start_date,
+    end_date;
+    dims = FLATTENED_DIMS,
+    name = nothing,
+)
     vars = _vars_to_iterable(vars)
+    dates_provided = !isnothing(start_date) && !isnothing(end_date)
+    if dates_provided
+        # Convert dates to Dates.DateTime if they are strings
+        start_date = Dates.DateTime(start_date)
+        end_date = Dates.DateTime(end_date)
 
-    # Check if start date and end date exist in vars
-    _check_dates_in_var(vars, start_date, end_date)
-
-    # Check if dates are unique and short name exists
-    for var in vars
-        allunique(ClimaAnalysis.dates(var)) || @warn(
-            "Dates in OutputVar with short name $(short_name(var)) are not unique. You will not be able to use GEnsembleBuilder",
-        )
+        _check_time_dim_of_vars(vars, start_date, end_date)
     end
 
     any(==(""), ClimaAnalysis.short_name.(vars)) && @warn(
@@ -441,18 +517,29 @@ function ObservationRecipe.observation(
     )
 
     # Get the flattened sample and metadata
-    windowed_vars =
-        ClimaAnalysis.window.(vars, "time", left = start_date, right = end_date)
-    flat_vars = map(var -> ClimaAnalysis.flatten(var; dims), windowed_vars)
+    maybe_windowed_vars =
+        dates_provided ?
+        ClimaAnalysis.window.(
+            vars,
+            "time",
+            left = start_date,
+            right = end_date,
+        ) : vars
+    flat_vars =
+        map(var -> ClimaAnalysis.flatten(var; dims), maybe_windowed_vars)
     stacked_sample = vcat((flat_var.data for flat_var in flat_vars)...)
     metadata = [(flat_var.metadata for flat_var in flat_vars)...]
-    covar = ObservationRecipe.covariance(
-        covar_estimator,
-        vars,
-        start_date,
-        end_date;
-        dims,
-    )
+    if dates_provided
+        covar = ObservationRecipe.covariance(
+            covar_estimator,
+            vars,
+            start_date,
+            end_date;
+            dims,
+        )
+    else
+        covar = ObservationRecipe.covariance(covar_estimator, vars; dims)
+    end
 
     # Concatenate names and separating them with a semicolon
     isnothing(name) && (
@@ -470,7 +557,6 @@ function ObservationRecipe.observation(
         ),
     )
 end
-
 """
     short_names(obs::EKP.Observation)
 

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -1,4 +1,34 @@
 """
+    _check_time_dim_of_vars(vars, start_date, end_date)
+
+Checking the time dimension of `vars`, `start_date`, and `end_date`.
+
+This function checks the the time dimension of `vars` with `_check_time_dim`,
+the start date and end dates are in `vars`, the `start_date` is before the
+`end_date`, and all dates are unique in `vars`.
+
+This function is used when making an `EKP.Observation` or covariance matrix.
+"""
+function _check_time_dim_of_vars(vars, start_date, end_date)
+    for var in vars
+        _check_time_dim(var)
+    end
+
+    # Check if dates for start_date and end_date are in var
+    _check_dates_in_var(vars, start_date, end_date)
+
+    start_date <= end_date || error("$start_date should earlier than $end_date")
+
+    # Check if dates are unique and short name exists
+    for var in vars
+        allunique(ClimaAnalysis.dates(var)) || @warn(
+            "Dates in OutputVar with short name $(short_name(var)) are not unique. You will not be able to use GEnsembleBuilder",
+        )
+    end
+    return nothing
+end
+
+"""
     _check_dates_in_var(vars::Iterable{OutputVar}, start_date, end_date)
 
 Check `start_date` and `end_date` are in `vars`.

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -335,9 +335,11 @@ end
         initialize
 
     lon = [-45.0, 0.0, 45.0]
+    x = [1.0]
     lon_var =
         TemplateVar() |>
         add_dim("lon", lon, units = "degrees") |>
+        add_dim("x", x, units = "m") |>
         add_dim("time", time, units = "s") |>
         add_attribs(
             short_name = "hi",
@@ -393,7 +395,8 @@ end
                 "time",
                 left = start_date,
                 right = end_date,
-            ),
+            );
+            dims = ext.FLATTENED_DIMS,
         )
     end
 
@@ -410,7 +413,7 @@ end
         @test EnsembleBuilder.fill_g_ens_col!(
             g_ens_builder,
             i,
-            permutedims(lon_var, ("time", "lon")),
+            permutedims(lon_var, ("time", "lon", "x")),
         )
     end
     @test EnsembleBuilder.is_complete(g_ens_builder)

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -314,6 +314,56 @@ end
     @test matched_var.attributes == var.attributes
 end
 
+@testset "GEnsembleBuilder with OutputVar with no time dimension" begin
+    lon = [-45.0, 0.0, 45.0]
+    x = [1.0, 3.0]
+    lon_var =
+        TemplateVar() |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("x", x, units = "m") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            super = "fun",
+            units = "m",
+        ) |>
+        one_to_n_data() |>
+        initialize
+
+    covar_estimator = ObservationRecipe.ScalarCovariance()
+
+    obs_vec = [ObservationRecipe.observation(covar_estimator, lon_var)]
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => obs_vec,
+            "names" => ["1"],
+            "minibatcher" =>
+                ClimaCalibrate.minibatcher_over_samples([1], 1),
+        ),
+    )
+
+    prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
+    eki = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+
+    g_ens_builder = EnsembleBuilder.GEnsembleBuilder(eki)
+    g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    @test size(g_ens) == (6, EKP.get_N_ens(eki))
+    @test size(g_ens_builder.completed) == (1, EKP.get_N_ens(eki))
+    @test keys(g_ens_builder.metadata_by_short_name) == Set(["hi"])
+
+    for i in 1:3
+        @test !EnsembleBuilder.is_complete(g_ens_builder)
+        @test EnsembleBuilder.fill_g_ens_col!(g_ens_builder, i, lon_var)
+    end
+    @test EnsembleBuilder.is_complete(g_ens_builder)
+end
+
 @testset "Use GEnsembleBuilder for a fake calibration" begin
     pkgversion(EnsembleKalmanProcesses) > v"2.4.3" || return
 

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -1271,6 +1271,8 @@ end
 @testset "Observation" begin
     lat = [-90.0, -30.0, 30.0, 90.0]
     lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    x = [1.0, 2.0]
+    y = [3.0]
     time =
         ClimaAnalysis.Utils.date_to_time.(
             Dates.DateTime(2007, 12),
@@ -1281,6 +1283,8 @@ end
         add_dim("time", time, units = "s") |>
         add_dim("lon", lon, units = "degrees") |>
         add_dim("lat", lat, units = "degrees") |>
+        add_dim("x", x, units = "m") |>
+        add_dim("y", y, units = "m") |>
         add_attribs(
             short_name = "hi",
             long_name = "hello",
@@ -1325,8 +1329,13 @@ end
             left = start_date,
             right = end_date,
         )
-    data1 = ClimaAnalysis.flatten(window_dates(var)).data
-    data2 = ClimaAnalysis.flatten(window_dates(neg_var)).data
+    data1 =
+        ClimaAnalysis.flatten(window_dates(var); dims = ext.FLATTENED_DIMS).data
+    data2 =
+        ClimaAnalysis.flatten(
+            window_dates(neg_var);
+            dims = ext.FLATTENED_DIMS,
+        ).data
 
     flattened_data = vcat(data1, data2)
     @test obs.samples[1] == flattened_data
@@ -1341,9 +1350,9 @@ end
 
         # Test if metadata is correct by unflattening back to an OutputVar
         unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:80])
+            ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:160])
         neg_unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][81:end])
+            ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][161:end])
 
         windowed_var = window_dates(var)
         neg_windowed_var = window_dates(neg_var)

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -599,6 +599,44 @@ end
     )
 end
 
+@testset "ScalarCovariance for OutputVars with no time dimension" begin
+    lat = [-90.0, -30.0, 30.0, 90.0]
+    lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    var =
+        TemplateVar() |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            blah = "blah2",
+        ) |>
+        one_to_n_data(collected = true) |>
+        initialize
+
+    data_length = length(var.data)
+
+    # Only scalar
+    covar_estimator = ObservationRecipe.ScalarCovariance(scalar = 100.0)
+    scalar_covar = ObservationRecipe.covariance(covar_estimator, var)
+    @test Diagonal(ones(data_length) .* 100) == scalar_covar
+
+    # Scalar and latitude weights
+    covar_estimator = ObservationRecipe.ScalarCovariance(
+        scalar = 10.0,
+        use_latitude_weights = true,
+        min_cosd_lat = 0.2,
+    )
+    scalar_covar = ObservationRecipe.covariance(covar_estimator, var)
+    @test scalar_covar ==
+          10.0 .* Diagonal(
+        ClimaAnalysis.flatten(
+            ext._lat_weights_var(var, min_cosd_lat = 0.2),
+        ).data,
+    )
+end
+
 @testset "Latitude weights to matrix of samples" begin
     lat = [-90.0, -30.0, 30.0, 90.0]
     lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
@@ -1389,6 +1427,69 @@ end
         Dates.DateTime(2008, 8),
     )
 
+end
+
+@testset "Observation with no time dimension" begin
+    lat = [-90.0, -30.0, 30.0, 90.0]
+    lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    x = [1.0, 2.0]
+    y = [3.0]
+    var =
+        TemplateVar() |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_dim("x", x, units = "m") |>
+        add_dim("y", y, units = "m") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            blah = "blah2",
+        ) |>
+        one_to_n_data(collected = true) |>
+        initialize
+    neg_var = -2.0 * var
+    neg_var.attributes["hi"] = "hello"
+    neg_var.dim_attributes["lon"]["a dim"] = "attribute"
+
+    covar_estimator = ObservationRecipe.ScalarCovariance(scalar = 2.0)
+
+    obs = ObservationRecipe.observation(covar_estimator, (var, neg_var))
+
+    # We already test the covariance matrix, so we test if the flattened
+    # sample is formed correctly and if the metadata is correct
+    # Test if flattened sample is correct
+    data1 = ClimaAnalysis.flatten(var; dims = ext.FLATTENED_DIMS).data
+    data2 = ClimaAnalysis.flatten(neg_var; dims = ext.FLATTENED_DIMS).data
+
+    flattened_data = vcat(data1, data2)
+    @test obs.samples[1] == flattened_data
+
+    # Also check the observation name
+    @test obs.names == ["hi;-2.0 * hi"]
+
+    if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
+        # Test metadata in observation is there in the EKP object
+        @test obs.metadata isa Vector{T} where {T <: ClimaAnalysis.Var.Metadata}
+        @test length(obs.metadata) == 2
+
+        # Test if metadata is correct by unflattening back to an OutputVar
+        unflattened_var =
+            ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:40])
+        neg_unflattened_var =
+            ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][41:end])
+
+        # Test if the two OutputVars are equivalent
+        @test unflattened_var.data == var.data
+        @test unflattened_var.attributes == var.attributes
+        @test unflattened_var.dim_attributes == var.dim_attributes
+        @test unflattened_var.dims == var.dims
+
+        @test neg_unflattened_var.data == neg_var.data
+        @test neg_unflattened_var.attributes == neg_var.attributes
+        @test neg_unflattened_var.dim_attributes == neg_var.dim_attributes
+        @test neg_unflattened_var.dims == neg_var.dims
+    end
 end
 
 @testset "Short names of observation" begin

--- a/test/pbs_manager_unit_tests.jl
+++ b/test/pbs_manager_unit_tests.jl
@@ -3,7 +3,7 @@ import ClimaCalibrate
 
 @testset "PBSManager Unit Tests" begin
     @test ClimaCalibrate.get_manager() == ClimaCalibrate.PBSManager(1)
-    p = ClimaCalibrate.add_workers(1; time = 5, device = :cpu)
+    p = ClimaCalibrate.add_workers(1; time = 5, device = :gpu)
     @test nprocs() == length(p) + 1
     @test workers() == p
     @test remotecall_fetch(myid, 2) == 2
@@ -26,7 +26,7 @@ end
         o = out_file,
         q = "main",
         A = "UCIT0011",
-        l_select = "ncpus=1",
+        l_select = "1:ncpus=1:ngpus=1",
         l_walltime = "00:05:00",
     )
     @test nprocs() == length(p) + 1

--- a/test/pbs_unit_tests.jl
+++ b/test/pbs_unit_tests.jl
@@ -18,7 +18,7 @@ import ClimaCalibrate
     #PBS -A UCIT0011
     #PBS -q preempt
     #PBS -l walltime=00:01:00
-    #PBS -l select=1:ncpus=1
+    #PBS -l select=1:ncpus=1:ngpus=1
 
     sleep 10
     """

--- a/test/worker_backend.jl
+++ b/test/worker_backend.jl
@@ -19,7 +19,7 @@ if nworkers() == 1
             PBSManager(nprocs),
             q = "main",
             A = "UCIT0011",
-            l_select = "1:ncpus=1",
+            l_select = "1:ncpus=1:ngpus=1",
             l_walltime = "00:30:00",
         )
     else


### PR DESCRIPTION
For `ObservationRecipe` and `EnsembleBuilder`, there was an implicit assumption that calibration would always involve time series data. However, this may not always be the case. For example, instead of using the entire time series data, you may be interested in certain features of the time series data (e.g. where the minimum or maximum are or the amplitude if it is periodic data). This PR allows for `OutputVar`s with no time dimension to be used with the `GEnsembleBuilder` and `ObservationRecipe` with `ScalarCovariance`.

In the future, we may want to support `OutputVar`s with no time dimension for the `SVDplusDCovariance` estimator, but this can be done in another PR.

closes https://github.com/CliMA/ClimaCalibrate.jl/issues/267

# TODO

- [x] Reduce code duplication for `covariance` and `observation` in `ObservationRecipe` for `ScalarCovariance`