### PR TITLE
Remove packages from targets and extras

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,10 +55,8 @@ ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNStatistics = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ClimaAnalysis", "ClimaParams", "LinearAlgebra", "NaNStatistics", "OrderedCollections", "SafeTestsets", "Statistics", "Test"]
+test = ["Aqua", "ClimaAnalysis", "ClimaParams", "LinearAlgebra", "NaNStatistics", "SafeTestsets", "Test"]


### PR DESCRIPTION
This commit removes OrderedCollections and Statistics from the targets and extras list in the compat because they are dependencies in src now.

I noticed this from looking at the dependabot PRs.