### PR TITLE
Add plotting utilities for calibration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ main
   ensemble matrix as a vector of `OutputVar`s
   [#319](https://github.com/CliMA/ClimaCalibrate.jl/pull/319)
 - Add "How do I?" section in the documentation
+  [#330](https://github.com/CliMA/ClimaCalibrate.jl/pull/330)
+- Add `ClimaCalibrateMakie` extension for plotting ensemble members, the mean
+  forward map evaluation, and the observations
+  [#331](https://github.com/CliMA/ClimaCalibrate.jl/pull/331)
 
 v0.3.1
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ main
   `OutputVar`s and `reconstruct_g_mean` for reconstructing the mean of the G
   ensemble matrix as a vector of `OutputVar`s
   [#319](https://github.com/CliMA/ClimaCalibrate.jl/pull/319)
+- Add "How do I?" section in the documentation
 
 v0.3.1
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -21,14 +21,17 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 NaNStatistics = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
 
 [extensions]
 ClimaCalibrateClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
+ClimaCalibrateMakieExt = ["Makie"]
 
 [compat]
 Aqua = "0.8"
 ArnoldiMethod = "0.4.0"
+CairoMakie = "0.15"
 ClimaAnalysis = "0.5.20"
 ClimaParams = "0.10, 0.11, 0.12, 1"
 Dates = "1"
@@ -38,6 +41,7 @@ JLD2 = "0.4, 0.5, 0.6"
 LinearAlgebra = "1"
 LinearMaps = "3.11.4"
 Logging = "1.10, 1.11"
+Makie = "0.24"
 NaNStatistics = "0.6.8 - 0.6.50, 0.6.53"
 OrderedCollections = "1.3"
 Random = "1"
@@ -51,6 +55,7 @@ julia = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -59,4 +64,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ClimaAnalysis", "ClimaParams", "LinearAlgebra", "NaNStatistics", "SafeTestsets", "Test"]
+test = ["Aqua", "CairoMakie", "ClimaAnalysis", "ClimaParams", "LinearAlgebra", "NaNStatistics", "SafeTestsets", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,6 +12,7 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [weakdeps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ using Documenter
 using Documenter: doctest
 using ClimaCalibrate
 import ClimaAnalysis # needed to load ClimaAnalysis extension
+import CairoMakie # needed to load Makie extension
+import Makie # needed to load Makie extension
 using Base.CoreLogging
 using DocumenterCitations
 import Literate
@@ -39,6 +41,7 @@ makedocs(
         "Observations" => "observations.md",
         "Observation Recipes" => "observation_recipe.md",
         "G Ensemble Builder" => "ensemble_builder.md",
+        "Visualization" => "visualization.md",
         "How do I?" => "howdoi.md",
         "API" => "api.md",
     ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -168,3 +168,14 @@ ClimaCalibrate.Checker.SequentialIndicesChecker
 ClimaCalibrate.Checker.SignChecker
 ClimaCalibrate.Checker.check
 ```
+
+## Visualization Interface
+
+```@docs
+ClimaCalibrate.Visualization.plot_g
+ClimaCalibrate.Visualization.plot_g!
+ClimaCalibrate.Visualization.plot_g_mean
+ClimaCalibrate.Visualization.plot_g_mean!
+ClimaCalibrate.Visualization.plot_obs
+ClimaCalibrate.Visualization.plot_obs!
+```

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -1,0 +1,154 @@
+```@meta
+CurrentModule = ClimaCalibrate
+```
+
+# Visualization
+
+ClimaCalibrate provides primitive plotting utilities for plotting the mean
+forward map evaluation, columns of the G ensemble matrix, and the true
+observation via a `Makie` extension.
+
+!!! note "Scope of plotting utilities"
+    Since the plotting utilities are general, they may be insufficient for your
+    use case. The plotting functions do not use metadata in the
+    `EKP.EnsembleKalmanProcess` object, since the metadata are specific to the
+    calibration that you are conducting. Hence, if these plotting utilities are
+    insufficient, you should use the metadata to transform the data in the
+    `EKP.EnsembleKalmanProcess` object to data that is more suitable for
+    plotting.
+
+To plot the mean forward map evaluation, columns of the G ensemble matrix, and
+the true observation, you can use [`Visualization.plot_g_mean`](@ref),
+[`Visualization.plot_g`](@ref), and [`Visualization.plot_obs`](@ref)
+respectively. The mutating versions also exist as
+[`Visualization.plot_g_mean!`](@ref), [`Visualization.plot_g!`](@ref), and
+[`Visualization.plot_obs!`](@ref). All plotting functions takes an
+`EKP.EnsembleKalmanProcess` object to plot from. Additionally, the plotting
+function accept an `iter` keyword argument for plotting from a specific
+iteration. If the keyword argument is not provided, then the last iteration is
+used for plotting. You can expect all keyword arguments that work with
+`Makie.Lines` to also work with these plotting functions and that the plotting
+functions behave like `Makie` plotting functions.
+
+!!! tip "Keyword arguments"
+    You can enter `help?> ClimaCalibrate.Visualization.plot_g` in the Julia REPL
+    to get a list of keyword arguments that work with `Visualization.plot_g`.
+    You can do the same with the other plotting functions.
+
+## Example
+
+Here is a complete example where we use the plotting functions to plot the
+ensemble members, the mean forward map evaluation, and the true observations
+from the second iteration.
+
+```@setup plot
+import Dates
+import EnsembleKalmanProcesses as EKP
+using EnsembleKalmanProcesses.ParameterDistributions
+import ClimaAnalysis
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_time_dim,
+    add_lon_dim,
+    add_lat_dim,
+    add_data,
+    ones_data,
+    zeros_data,
+    one_to_n_data,
+    initialize
+import ClimaCalibrate
+import ClimaCalibrate: ObservationRecipe, EnsembleBuilder
+
+lat = [-90.0, -30.0, 30.0, 90.0]
+lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+time = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+data3d = [t * cos(x / 90) * sin(y / 180) for t in time, x in lon, y in lat]
+var =
+    TemplateVar() |>
+    add_dim("time", time, units = "s") |>
+    add_dim("lon", lon, units = "degrees") |>
+    add_dim("lat", lat, units = "degrees") |>
+    add_attribs(
+        short_name = "hi",
+        long_name = "hello",
+        start_date = "2007-12-1",
+    ) |>
+    add_data(; data = data3d) |>
+    initialize
+# neg_var = -2.0 * var
+# ClimaAnalysis.set_short_name!(neg_var, "neg_hi")
+
+covar_estimator = ObservationRecipe.ScalarCovariance(; scalar = 1.0)
+
+start_date = Dates.DateTime(2007, 12)
+end_date = start_date + Dates.Second(time[end])
+obs =
+    ObservationRecipe.observation(covar_estimator, (var,), start_date, end_date)
+
+obs_series = EKP.ObservationSeries(
+    Dict(
+        "observations" => [obs],
+        "names" => ["1"],
+        "minibatcher" => ClimaCalibrate.minibatcher_over_samples([1], 1),
+    ),
+)
+
+prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
+
+
+ekp = EKP.EnsembleKalmanProcess(
+    obs_series,
+    EKP.TransformUnscented(prior, impose_prior = true),
+    verbose = true,
+    scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+)
+
+iters = 3
+for _ in 1:iters
+    g_ens_builder = EnsembleBuilder.GEnsembleBuilder(ekp)
+    for i in 1:EKP.get_N_ens(ekp)
+        v = deepcopy(var)
+        v.data .+= i - 2
+        v.data .+= 0.1 * randn(size(v.data))
+        EnsembleBuilder.fill_g_ens_col!(g_ens_builder, i, v)
+    end
+    g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    EKP.update_ensemble!(ekp, g_ens)
+end
+```
+
+```@example plot
+import ClimaCalibrate
+# To use this extension, one of the Makie backends should be loaded
+import CairoMakie
+
+fig = CairoMakie.Figure()
+ax = CairoMakie.Axis(
+    fig[1, 1],
+    title = "G ensemble members, mean forward map evaluation, and observations",
+    xlabel = "Index",
+    ylabel = "Value",
+)
+g_plot = ClimaCalibrate.Visualization.plot_g!(
+    ax,
+    ekp;
+    iter = 2,
+    color = :black,
+    alpha = 0.2,
+)
+g_mean_plot =
+    ClimaCalibrate.Visualization.plot_g_mean!(ax, ekp; iter = 2, color = :black)
+obs_plot =
+    ClimaCalibrate.Visualization.plot_obs!(ax, ekp; iter = 2, color = :blue)
+
+CairoMakie.Legend(
+    fig[1, 2],
+    [g_plot, g_mean_plot, obs_plot],
+    ["G", "G mean", "Observation"],
+)
+
+fig
+```

--- a/ext/ClimaCalibrateMakieExt.jl
+++ b/ext/ClimaCalibrateMakieExt.jl
@@ -1,0 +1,174 @@
+module ClimaCalibrateMakieExt
+
+import Makie
+import EnsembleKalmanProcesses as EKP
+import ClimaCalibrate
+
+import ClimaCalibrate.Visualization:
+    plot_g, plot_g!, plot_g_mean, plot_g_mean!, plot_obs, plot_obs!
+
+"""
+    plot_g
+
+Plot members of the G ensemble matrix as line plots.
+
+If the `iter` keyword argument is not passed, then this plot the last completed
+G ensemble matrix. Otherwise, it plots the `iter`th G ensemble matrix.
+"""
+Makie.@recipe Plot_G (ekp,) begin
+    "Iteration of G ensemble matrix to plot. If `nothing`, then use the last
+    iteration"
+    iter = nothing
+    Makie.documented_attributes(Makie.Lines)...
+end
+
+"""
+    Makie.plot!(g_ens_plot::Plot_G)
+
+Plot members of the G ensemble matrix as line plots.
+
+This function is called when using `Visualization.plot_g` or
+`Visualization.plot_g!`.
+"""
+function Makie.plot!(g_ens_plot::Plot_G)
+    ekp = g_ens_plot.ekp[]
+    iter = _iter_or_total(ekp, g_ens_plot.iter[])
+    g_ens_matrix = EKP.get_g(ekp, iter)
+    for j in axes(g_ens_matrix, 2)
+        ensemble_member = view(g_ens_matrix, :, j)
+        Makie.lines!(
+            g_ens_plot,
+            g_ens_plot.attributes,
+            1:length(ensemble_member),
+            ensemble_member,
+        )
+    end
+    return g_ens_plot
+end
+
+"""
+    plot_g_mean
+
+Plot mean forward map evaluation as a line plot.
+
+If the `iter` keyword argument is not passed, then this plot the last mean
+forward map evaluation. Otherwise, it plots the `iter`th mean forward map
+evaluation.
+"""
+Makie.@recipe Plot_G_Mean (ekp,) begin
+    "Iteration of the G ensemble matrix to plot. If `nothing`, then use the last
+    iteration"
+    iter = nothing
+    Makie.documented_attributes(Makie.Lines)...
+end
+
+"""
+    Makie.plot!(g_ens_plot::Plot_G_Mean)
+
+Plot mean forward map evaluation as a line plot.
+
+This function is called when using `Visualization.plot_g_mean` or
+`Visualization.plot_g_mean!`.
+"""
+function Makie.plot!(g_mean_plot::Plot_G_Mean)
+    ekp = g_mean_plot.ekp[]
+    iter = _iter_or_total(ekp, g_mean_plot.iter[])
+    ensemble_member = EKP.get_g_mean(ekp, iter)
+    Makie.lines!(
+        g_mean_plot,
+        g_mean_plot.attributes,
+        1:length(ensemble_member),
+        ensemble_member,
+    )
+    return g_mean_plot
+end
+
+
+"""
+    plot_obs
+
+Plot the observations as a line plot.
+
+If the `iter` keyword argument is not passed, then this plot the observations
+for the last iteration. Otherwise, it plots the observations for the `iter`th
+iteration.
+"""
+Makie.@recipe Plot_Obs (ekp,) begin
+    "Iteration of the G ensemble matrix to plot. If `nothing`, then use the last
+    iteration"
+    iter = nothing
+    Makie.documented_attributes(Makie.Lines)...
+end
+
+"""
+    Makie.plot!(g_ens_plot::Plot_Obs)
+
+Plot the observations as a line plot.
+
+This function is called when using `Visualization.plot_obs` or
+`Visualization.plot_obs!`.
+"""
+function Makie.plot!(obs_plot::Plot_Obs)
+    ekp = obs_plot.ekp[]
+    iter = _iter_or_total(ekp, obs_plot.iter[])
+    obs_series = EKP.get_observation_series(ekp)
+    obs = ClimaCalibrate.get_observations_for_nth_iteration(obs_series, iter)
+    stacked_obs = mapreduce(EKP.get_obs, vcat, obs)
+    Makie.lines!(
+        obs_plot,
+        obs_plot.attributes,
+        1:length(stacked_obs),
+        stacked_obs,
+    )
+    return obs_plot
+end
+
+@static if pkgversion(Makie) >= v"0.24.11"
+    function Makie.preferred_axis_attributes(
+        ::Type{Makie.Axis},
+        g_ens_plot::Plot_G,
+    )
+        iter = _iter_or_total(g_ens_plot.ekp[], g_ens_plot.iter[])
+        xlabel = "Index"
+        ylabel = "Value"
+        title = "G ensemble members for iteration $iter"
+        return (; title, ylabel, xlabel)
+    end
+
+    function Makie.preferred_axis_attributes(
+        ::Type{Makie.Axis},
+        g_mean_plot::Plot_G_Mean,
+    )
+        iter = _iter_or_total(g_mean_plot.ekp[], g_mean_plot.iter[])
+        xlabel = "Index"
+        ylabel = "Value"
+        title = "Mean G for iteration $iter"
+        return (; title, ylabel, xlabel)
+    end
+
+    function Makie.preferred_axis_attributes(
+        ::Type{Makie.Axis},
+        obs_plot::Plot_Obs,
+    )
+        iter = _iter_or_total(obs_plot.ekp[], obs_plot.iter[])
+        xlabel = "Index"
+        ylabel = "Value"
+        title = "Observations for iteration $iter"
+        return (; title, ylabel, xlabel)
+    end
+end
+
+"""
+    _iter_or_total(ekp::EKP.EnsembleKalmanProcess, iter::Union{Int, Nothing})
+
+Return `iter` if `iter` is an `Int` or the total number of iterations if `iter`
+is `nothing`.
+"""
+function _iter_or_total(::EKP.EnsembleKalmanProcess, iter::Int)
+    return iter
+end
+function _iter_or_total(ekp::EKP.EnsembleKalmanProcess, ::Nothing)
+    return EKP.get_N_iterations(ekp)
+end
+
+end

--- a/src/ClimaCalibrate.jl
+++ b/src/ClimaCalibrate.jl
@@ -21,4 +21,7 @@ include("ensemble_builder.jl")
 include("checkers.jl")
 include("svd_analysis.jl")
 
+include("visualization.jl")
+export Visualization
+
 end # module ClimaCalibrate

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,0 +1,67 @@
+module Visualization
+
+export plot_g, plot_g!, plot_g_mean, plot_g_mean!, plot_obs, plot_obs!
+
+"""
+    plot_g
+
+Plot members of the G ensemble matrix as line plots.
+
+If the `iter` keyword argument is not passed, then this plot the last completed
+G ensemble matrix. Otherwise, it plots the `iter`th G ensemble matrix.
+
+All `Makie` keyword arguments compatible with `Makie.lines` is also compatible
+with this function.
+"""
+function plot_g end
+
+"""
+    plot_g!
+
+This is the mutating variant of the plotting function [`plot_g`](@ref).
+"""
+function plot_g! end
+
+"""
+    plot_g_mean
+
+Plot mean forward map evaluation as a line plot.
+
+If the `iter` keyword argument is not passed, then this plot the last mean
+forward map evaluation. Otherwise, it plots the `iter`th mean forward map
+evaluation.
+
+All `Makie` keyword arguments compatible with `Makie.lines` is also compatible
+with this function.
+"""
+function plot_g_mean end
+
+"""
+    plot_g_mean!
+
+This is the mutating variant of the plotting function [`plot_g_mean`](@ref).
+"""
+function plot_g_mean! end
+
+
+"""
+    plot_obs
+
+Plot the observations as a line plot.
+
+If the `iter` keyword argument is not passed, then this plot the observations of
+the last iteration. Otherwise, plot the observations of the `iter`th iteration.
+
+All `Makie` keyword arguments compatible with `Makie.lines` is also compatible
+with this function.
+"""
+function plot_obs end
+
+"""
+    plot_obs!
+
+This is the mutating variant of the plotting function [`plot_obs`](@ref).
+"""
+function plot_obs! end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using SafeTestsets
 @safetestset "Observation recipe" begin include("observation_recipe.jl") end
 @safetestset "Ensemble builder" begin include("ensemble_builder.jl") end
 @safetestset "SVD analysis" begin include("svd_analysis.jl") end
+@safetestset "Visualization" begin include("visualization.jl") end
 #! format: on
 
 nothing

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -1,0 +1,126 @@
+using Test
+import Dates
+import CairoMakie
+import ClimaCalibrate
+import ClimaCalibrate: ObservationRecipe, EnsembleBuilder
+import ClimaAnalysis
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_data,
+    one_to_n_data,
+    initialize
+import EnsembleKalmanProcesses as EKP
+using EnsembleKalmanProcesses.ParameterDistributions
+
+@testset "Visualization of G ensemble matrix and observations" begin
+    lat = [-90.0, -30.0, 30.0, 90.0]
+    lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    time = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    var =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            blah = "blah2",
+        ) |>
+        one_to_n_data(collected = true) |>
+        initialize
+    neg_var = -2.0 * var
+    ClimaAnalysis.set_short_name!(neg_var, "neg_hi")
+
+    covar_estimator = ObservationRecipe.ScalarCovariance(; scalar = 1.0)
+
+    start_date = Dates.DateTime(2007, 12)
+    end_date = start_date + Dates.Second(time[end])
+    obs = ObservationRecipe.observation(
+        covar_estimator,
+        (var, neg_var),
+        start_date,
+        end_date,
+    )
+
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => [obs],
+            "names" => ["1"],
+            "minibatcher" =>
+                ClimaCalibrate.minibatcher_over_samples([1], 1),
+        ),
+    )
+
+    prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
+
+
+    ekp = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+
+    iters = 3
+    for i in 1:iters
+        g_ens_builder = EnsembleBuilder.GEnsembleBuilder(ekp)
+        for j in 1:EKP.get_N_ens(ekp)
+            EnsembleBuilder.fill_g_ens_col!(g_ens_builder, j, Float64(j))
+        end
+        g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+        g_ens .+= i
+        EKP.update_ensemble!(ekp, g_ens)
+    end
+
+    # Create directory to save plots to
+    plot_dir = mktempdir(cleanup = false)
+    @info "Plots" plot_dir
+
+    # Test non mutating version
+    fig = CairoMakie.Figure(; size = (750, 1000))
+    plot_fns = [
+        ClimaCalibrate.Visualization.plot_g,
+        ClimaCalibrate.Visualization.plot_g_mean,
+        ClimaCalibrate.Visualization.plot_obs,
+    ]
+    colors = [:tomato, :lime, :skyblue]
+    for (i, (plot_fn, color)) in enumerate(zip(plot_fns, colors))
+        plot_fn(fig[i, 1], ekp; iter = 2, color)
+        plot_fn(fig[i, 2], ekp; color)
+    end
+    CairoMakie.save(joinpath(plot_dir, "g_ensemble_and_obs_plot.png"), fig)
+
+    # Test mutating version
+    fig = CairoMakie.Figure(; size = (1000, 500))
+    ax1 = CairoMakie.Axis(
+        fig[1, 1],
+        xlabel = "Index",
+        ylabel = "Value",
+        title = "G ensemble members and observations for 2nd iteration",
+    )
+    ax2 = CairoMakie.Axis(
+        fig[1, 2],
+        xlabel = "Index",
+        ylabel = "Value",
+        title = "G ensemble members and observations for last iteration",
+    )
+    mutating_plot_fns = [
+        ClimaCalibrate.Visualization.plot_g!,
+        ClimaCalibrate.Visualization.plot_g_mean!,
+        ClimaCalibrate.Visualization.plot_obs!,
+    ]
+    colors = [:tomato, :lime, :skyblue]
+    for (i, (mutating_plot_fn, color)) in
+        enumerate(zip(mutating_plot_fns, colors))
+        mutating_plot_fn(ax1, ekp; iter = 2, color)
+        mutating_plot_fn(ax2, ekp; color)
+    end
+    CairoMakie.save(
+        joinpath(plot_dir, "g_ensemble_and_obs_plot_from_mutating_axes.png"),
+        fig,
+    )
+end


### PR DESCRIPTION
This PR adds plotting utilities for calibration by allowing users to plot columns of the G ensemble matrix, the mean forward map evaluation, and the observations for any given iteration as line plots.

TODO

- [x] Add docs
- [x] Add tests

For the plotting utilities added here, they do not assume that `ObservationRecipe` was used to make the observations. If this is the case, there is more potential for better plotting utilities. For example, you can denote regions of the line plots that correspond to a variable and plot the short names from the metadata in the observations. This could be done in this PR or another PR.