### PR TITLE
Refresh README, LICENSE, and NOTICE metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023-2026 California Institute of Technology (Climate Modeling Alliance)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2023-2026 California Institute of Technology (Climate Modeling Alliance)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ calibration pipelines using minimal boilerplate.</strong>
 
 [![dev][docs-dev-img]][docs-dev-url]
 [![ghaci][gha-ci-img]][gha-ci-url]
+[![buildkite-ci][bk-ci-img]][bk-ci-url]
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://CliMA.github.io/ClimaCalibrate.jl/dev/
 
 [gha-ci-img]: https://github.com/CliMA/ClimaCalibrate.jl/actions/workflows/ci.yml/badge.svg
 [gha-ci-url]: https://github.com/CliMA/ClimaCalibrate.jl/actions/workflows/ci.yml
+
+[bk-ci-img]: https://badge.buildkite.com/1607c5a46f9adbaf939f2ff06ddda3fa971371bfa29188d23c.svg?branch=main
+[bk-ci-url]: https://buildkite.com/clima/climacalibrate-ci
 
 The recommended Julia version is: Stable release v1.11.4
 


### PR DESCRIPTION
## Summary

- Filled in the LICENSE copyright line, which was previously an unfilled template placeholder, and added a new NOTICE file.
- Copyright set to `2023-2026 California Institute of Technology (Climate Modeling Alliance)`, using the repo's actual first-commit year.
- Buildkite badge added, scoped to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3GJ3g8X3sQuPCnGcrwfTy