### PR TITLE
Update minimum Julia version to 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Statistics = "1"
 TOML = "1"
 Test = "1"
 YAML = "0.4"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
This PR updates the minimum Julia version to 1.10, which is needed to release the newest version of the package (0.3.2). 
See error from [AutoMerge](https://github.com/JuliaRegistries/General/pull/162463):
```
┌ Error: Was not able to successfully `Pkg.add` the package on julia 1.9.4 (lowest compatible version)
└ @ AutoMerge ~/.julia/packages/AutoMerge/aXNpV/src/guidelines.jl:1204
```