### PR TITLE
Fix bug in build_samples for 0D OutputVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,19 @@ ClimaCalibrate.jl Release Notes
 main
 -------
 
+- Fix a bug where `SampleBuilder.build_samples` did not work with `OutputVar`s
+  with no dimensions. `SampleBuilder`, `ObservationRecipe`, and
+  `EnsembleBuilder` now support `OutputVar`s with no dimensions. This requires
+  versions of ClimaAnalysis after v0.5.23.
+
+v0.4.0
+-------
+
 - Update minimum Julia version to 1.10
   [#340](https://github.com/CliMA/ClimaCalibrate.jl/pull/340)
 - Add the `workers_per_node` keyword argument to `add_workers`, which runs
   multiple independent workers on a single allocation
   [#341](https://github.com/CliMA/ClimaCalibrate.jl/pull/341)
-- Add the `workers_per_node` keyword argument to `add_workers`, which runs multiple independent workers on a single allocation.
 - Add the `SampleBuilder` module and refactor `ObservationRecipe`
   [#334](https://github.com/CliMA/ClimaCalibrate.jl/pull/334)
   - The `SampleBuilder` module handles transforming one or more

--- a/ext/sample_builder.jl
+++ b/ext/sample_builder.jl
@@ -158,7 +158,10 @@ function change_data_type(var, FT)
     # We change the data type since the metadata of the flattened OutputVar
     # stores it values using the type of var.data
     eltype(var.data) === FT && return var
-    return ClimaAnalysis.remake(var, data = FT.(var.data))
+    # Use map instead of broadcasting, because broadcasting over a
+    # zero-dimensional array returns a scalar instead of a zero-dimensional
+    # array
+    return ClimaAnalysis.remake(var, data = map(FT, var.data))
 end
 
 """

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -386,6 +386,55 @@ end
     @test EnsembleBuilder.is_complete(g_ens_builder)
 end
 
+@testset "GEnsembleBuilder with OutputVars with no dimensions" begin
+    make_0d_var(val; attribs...) =
+        TemplateVar() |>
+        add_attribs(; units = "K", attribs...) |>
+        add_data(data = fill(val)) |>
+        initialize
+
+    ts_var = make_0d_var(300.0, short_name = "ts")
+    ta_var = make_0d_var(250.0, short_name = "ta")
+
+    covar_estimator = ObservationRecipe.ScalarCovariance()
+
+    sample_collection = SampleBuilder.build_samples([ts_var, ta_var])
+    obs_vec =
+        [ObservationRecipe.observation(covar_estimator, sample_collection, 1)]
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => obs_vec,
+            "names" => ["1"],
+            "minibatcher" =>
+                ClimaCalibrate.minibatcher_over_samples([1], 1),
+        ),
+    )
+
+    prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
+    eki = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+
+    g_ens_builder = EnsembleBuilder.GEnsembleBuilder(eki)
+    g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    @test size(g_ens) == (2, EKP.get_N_ens(eki))
+    @test size(g_ens_builder.completed) == (2, EKP.get_N_ens(eki))
+    @test keys(g_ens_builder.metadata_by_short_name) == Set(["ts", "ta"])
+
+    for i in 1:EKP.get_N_ens(eki)
+        @test !EnsembleBuilder.is_complete(g_ens_builder)
+        @test EnsembleBuilder.fill_g_ens_col!(g_ens_builder, i, ts_var)
+        @test EnsembleBuilder.fill_g_ens_col!(g_ens_builder, i, ta_var)
+    end
+    @test EnsembleBuilder.is_complete(g_ens_builder)
+    g_ens = EnsembleBuilder.get_g_ensemble(g_ens_builder)
+    @test all(g_ens[1, :] .== 300.0)
+    @test all(g_ens[2, :] .== 250.0)
+end
+
 @testset "Use GEnsembleBuilder for a fake calibration" begin
     pkgversion(EnsembleKalmanProcesses) > v"2.4.3" || return
 

--- a/test/ensemble_builder.jl
+++ b/test/ensemble_builder.jl
@@ -436,8 +436,6 @@ end
 end
 
 @testset "Use GEnsembleBuilder for a fake calibration" begin
-    pkgversion(EnsembleKalmanProcesses) > v"2.4.3" || return
-
     time = ClimaAnalysis.Utils.date_to_time.(
         Dates.DateTime(2007, 12),
         [Dates.DateTime(2007, 12) + Dates.Month(3 * i) for i in 0:11],

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -583,15 +583,11 @@ end
     )
     svd_plus_d_covar =
         ObservationRecipe.covariance(covar_estimator, sample_collection32)
-
-    if pkgversion(EnsembleKalmanProcesses) >= v"2.5.0"
-        # See https://github.com/CliMA/EnsembleKalmanProcesses.jl/issues/504
-        @test eltype(svd_plus_d_covar.svd_cov.S) == Float32
-        @test eltype(svd_plus_d_covar.svd_cov.U) == Float32
-        @test eltype(svd_plus_d_covar.svd_cov.V) == Float32
-        @test eltype(svd_plus_d_covar.svd_cov.Vt) == Float32
-        @test eltype(svd_plus_d_covar.diag_cov.diag) == Float32
-    end
+    @test eltype(svd_plus_d_covar.svd_cov.S) == Float32
+    @test eltype(svd_plus_d_covar.svd_cov.U) == Float32
+    @test eltype(svd_plus_d_covar.svd_cov.V) == Float32
+    @test eltype(svd_plus_d_covar.svd_cov.Vt) == Float32
+    @test eltype(svd_plus_d_covar.diag_cov.diag) == Float32
 
     # Float32 samples must stay Float32 even when model_error_scale and
     # regularization are given as Float64 literals (the diagonal part should not
@@ -603,9 +599,7 @@ end
     svd_plus_d_covar =
         ObservationRecipe.covariance(covar_estimator, sample_collection32)
     @test eltype(svd_plus_d_covar.diag_cov.diag) == Float32
-    if pkgversion(EnsembleKalmanProcesses) >= v"2.5.0"
-        @test eltype(svd_plus_d_covar.svd_cov.S) == Float32
-    end
+    @test eltype(svd_plus_d_covar.svd_cov.S) == Float32
 
     # Error handling: negative rank
     @test_throws ErrorException ObservationRecipe.SVDplusDCovariance(rank = -1)
@@ -1082,32 +1076,29 @@ end
     # Also check the observation name
     @test obs.names == ["hi;-2.0 * hi"]
 
-    if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
-        # Test metadata in observation is there in the EKP object
-        @test obs.metadata isa Vector{T} where {T <: ClimaAnalysis.Var.Metadata}
-        @test length(obs.metadata) == 2
+    # Test metadata in observation is there in the EKP object
+    @test obs.metadata isa Vector{T} where {T <: ClimaAnalysis.Var.Metadata}
+    @test length(obs.metadata) == 2
 
-        # Test if metadata is correct by unflattening back to an OutputVar
-        unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:160])
-        neg_unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][161:end])
+    # Test if metadata is correct by unflattening back to an OutputVar
+    unflattened_var =
+        ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:160])
+    neg_unflattened_var =
+        ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][161:end])
 
-        windowed_var = window_dates(var)
-        neg_windowed_var = window_dates(neg_var)
+    windowed_var = window_dates(var)
+    neg_windowed_var = window_dates(neg_var)
 
-        # Test if the two OutputVars are equivalent
-        @test unflattened_var.data == windowed_var.data
-        @test unflattened_var.attributes == windowed_var.attributes
-        @test unflattened_var.dim_attributes == windowed_var.dim_attributes
-        @test unflattened_var.dims == windowed_var.dims
+    # Test if the two OutputVars are equivalent
+    @test unflattened_var.data == windowed_var.data
+    @test unflattened_var.attributes == windowed_var.attributes
+    @test unflattened_var.dim_attributes == windowed_var.dim_attributes
+    @test unflattened_var.dims == windowed_var.dims
 
-        @test neg_unflattened_var.data == neg_windowed_var.data
-        @test neg_unflattened_var.attributes == neg_windowed_var.attributes
-        @test neg_unflattened_var.dim_attributes ==
-              neg_windowed_var.dim_attributes
-        @test neg_unflattened_var.dims == neg_windowed_var.dims
-    end
+    @test neg_unflattened_var.data == neg_windowed_var.data
+    @test neg_unflattened_var.attributes == neg_windowed_var.attributes
+    @test neg_unflattened_var.dim_attributes == neg_windowed_var.dim_attributes
+    @test neg_unflattened_var.dims == neg_windowed_var.dims
 
     # Error handling for out-of-bounds sample index
     @test_throws ErrorException ObservationRecipe.observation(
@@ -1162,28 +1153,26 @@ end
     # Also check the observation name
     @test obs.names == ["hi;-2.0 * hi"]
 
-    if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
-        # Test metadata in observation is there in the EKP object
-        @test obs.metadata isa Vector{T} where {T <: ClimaAnalysis.Var.Metadata}
-        @test length(obs.metadata) == 2
+    # Test metadata in observation is there in the EKP object
+    @test obs.metadata isa Vector{T} where {T <: ClimaAnalysis.Var.Metadata}
+    @test length(obs.metadata) == 2
 
-        # Test if metadata is correct by unflattening back to an OutputVar
-        unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:40])
-        neg_unflattened_var =
-            ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][41:end])
+    # Test if metadata is correct by unflattening back to an OutputVar
+    unflattened_var =
+        ClimaAnalysis.unflatten(obs.metadata[1], obs.samples[1][1:40])
+    neg_unflattened_var =
+        ClimaAnalysis.unflatten(obs.metadata[2], obs.samples[1][41:end])
 
-        # Test if the two OutputVars are equivalent
-        @test unflattened_var.data == var.data
-        @test unflattened_var.attributes == var.attributes
-        @test unflattened_var.dim_attributes == var.dim_attributes
-        @test unflattened_var.dims == var.dims
+    # Test if the two OutputVars are equivalent
+    @test unflattened_var.data == var.data
+    @test unflattened_var.attributes == var.attributes
+    @test unflattened_var.dim_attributes == var.dim_attributes
+    @test unflattened_var.dims == var.dims
 
-        @test neg_unflattened_var.data == neg_var.data
-        @test neg_unflattened_var.attributes == neg_var.attributes
-        @test neg_unflattened_var.dim_attributes == neg_var.dim_attributes
-        @test neg_unflattened_var.dims == neg_var.dims
-    end
+    @test neg_unflattened_var.data == neg_var.data
+    @test neg_unflattened_var.attributes == neg_var.attributes
+    @test neg_unflattened_var.dim_attributes == neg_var.dim_attributes
+    @test neg_unflattened_var.dims == neg_var.dims
 end
 
 @testset "Observation with OutputVars with no dimensions" begin
@@ -1219,45 +1208,41 @@ end
 end
 
 @testset "Short names of observation" begin
-    if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
-        time = ClimaAnalysis.Utils.date_to_time.(
-            Dates.DateTime(2007, 12),
-            [Dates.DateTime(2007, 12) + Dates.Month(i) for i in 0:2],
-        )
-        var1 =
-            TemplateVar() |>
-            add_dim("time", time, units = "s") |>
-            add_attribs(short_name = "Hello", start_date = "2007-12-1") |>
-            initialize
+    time = ClimaAnalysis.Utils.date_to_time.(
+        Dates.DateTime(2007, 12),
+        [Dates.DateTime(2007, 12) + Dates.Month(i) for i in 0:2],
+    )
+    var1 =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(short_name = "Hello", start_date = "2007-12-1") |>
+        initialize
 
-        var2 =
-            TemplateVar() |>
-            add_dim("time", time, units = "s") |>
-            add_attribs(short_name = "world!", start_date = "2007-12-1") |>
-            initialize
+    var2 =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(short_name = "world!", start_date = "2007-12-1") |>
+        initialize
 
-        var3 =
-            TemplateVar() |>
-            add_dim("time", time, units = "s") |>
-            add_attribs(no_short_name = "no", start_date = "2007-12-1") |>
-            initialize
+    var3 =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(no_short_name = "no", start_date = "2007-12-1") |>
+        initialize
 
-        covar_estimator = ObservationRecipe.ScalarCovariance()
-        sample_collection = SampleBuilder.build_samples_by_times(
-            [var1, var2, var3],
-            [(Dates.DateTime(2007, 12, 1), Dates.DateTime(2008, 1, 1))],
-        )
-        obs =
-            ObservationRecipe.observation(covar_estimator, sample_collection, 1)
-        @test isequal(
-            ObservationRecipe.short_names(obs),
-            ["Hello", "world!", nothing],
-        )
-    end
+    covar_estimator = ObservationRecipe.ScalarCovariance()
+    sample_collection = SampleBuilder.build_samples_by_times(
+        [var1, var2, var3],
+        [(Dates.DateTime(2007, 12, 1), Dates.DateTime(2008, 1, 1))],
+    )
+    obs = ObservationRecipe.observation(covar_estimator, sample_collection, 1)
+    @test isequal(
+        ObservationRecipe.short_names(obs),
+        ["Hello", "world!", nothing],
+    )
 end
 
 @testset "Get information about metadata from nth iteration" begin
-    pkgversion(EnsembleKalmanProcesses) > v"2.4.3" || return
     time = ClimaAnalysis.Utils.date_to_time.(
         Dates.DateTime(2007, 12),
         [Dates.DateTime(2007, 12) + Dates.Month(3 * i) for i in 0:47],
@@ -1484,207 +1469,203 @@ end
 end
 
 @testset "Reconstruct mean g ens final" begin
-    if pkgversion(EnsembleKalmanProcesses) > v"2.4.3"
-        # Test with a two OutputVars and two iterations with a single
-        # observation (no observation series)
-        time = ClimaAnalysis.Utils.date_to_time.(
-            Dates.DateTime(2007, 12),
-            [Dates.DateTime(2007, 12) + Dates.Month(3 * i) for i in 0:47],
-        )
-        time_var =
-            TemplateVar() |>
-            add_dim("time", time, units = "s") |>
-            add_attribs(
-                short_name = "hi",
-                long_name = "hello",
-                start_date = "2007-12-1",
-                blah = "blah2",
-            ) |>
-            one_to_n_data() |>
-            initialize
+    # Test with a two OutputVars and two iterations with a single
+    # observation (no observation series)
+    time = ClimaAnalysis.Utils.date_to_time.(
+        Dates.DateTime(2007, 12),
+        [Dates.DateTime(2007, 12) + Dates.Month(3 * i) for i in 0:47],
+    )
+    time_var =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            blah = "blah2",
+        ) |>
+        one_to_n_data() |>
+        initialize
 
-        lon = [-45.0, 0.0, 45.0]
-        lon_var =
-            TemplateVar() |>
-            add_dim("lon", lon, units = "degrees") |>
-            add_dim("time", time, units = "s") |>
-            add_attribs(
-                short_name = "hi",
-                long_name = "hello",
-                start_date = "2007-12-1",
-                super = "fun",
-            ) |>
-            one_to_n_data() |>
-            initialize
+    lon = [-45.0, 0.0, 45.0]
+    lon_var =
+        TemplateVar() |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(
+            short_name = "hi",
+            long_name = "hello",
+            start_date = "2007-12-1",
+            super = "fun",
+        ) |>
+        one_to_n_data() |>
+        initialize
 
-        covar_estimator = ObservationRecipe.SeasonalDiagonalCovariance()
-        sample_date_ranges = [
-            (Dates.DateTime(i, 12, 1), Dates.DateTime(i + 1, 9, 1)) for
-            i in 2007:2010
-        ]
-        sc = SampleBuilder.build_samples_by_times(
-            [time_var, lon_var],
-            sample_date_ranges,
-        )
-        obs = ObservationRecipe.observation(covar_estimator, sc, 1)
+    covar_estimator = ObservationRecipe.SeasonalDiagonalCovariance()
+    sample_date_ranges = [
+        (Dates.DateTime(i, 12, 1), Dates.DateTime(i + 1, 9, 1)) for
+        i in 2007:2010
+    ]
+    sc = SampleBuilder.build_samples_by_times(
+        [time_var, lon_var],
+        sample_date_ranges,
+    )
+    obs = ObservationRecipe.observation(covar_estimator, sc, 1)
 
-        prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
+    prior = constrained_gaussian("pi_groups_coeff", 1.0, 0.3, 0, Inf)
 
-        eki = EKP.EnsembleKalmanProcess(
-            obs,
-            EKP.TransformUnscented(prior, impose_prior = true),
-            verbose = true,
-            scheduler = EKP.DataMisfitController(on_terminate = "continue"),
-        )
-        G_ens = reshape(collect(1.0:48.0), 16, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+    eki = EKP.EnsembleKalmanProcess(
+        obs,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+    G_ens = reshape(collect(1.0:48.0), 16, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
 
-        # Test OutputVar is constructed correctly
-        @test length(vars) == 2
-        for (i, var) in enumerate((time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            @test vars[i].dims["time"] == first(var.dims["time"], 4)
-        end
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
-
-        # Another iteration
-        G_ens = reshape(collect(100.0:147.0), 16, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
-
-        # Test OutputVar is reconstructed correctly
-        @test length(vars) == 2
-        for (i, var) in enumerate((time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            @test vars[i].dims["time"] == first(var.dims["time"], 4)
-        end
-
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
-
-        # Test with multiple OutputVars with two iterations with a minibatch of
-        # size 1 and an observation series
-        obs1 = ObservationRecipe.observation(covar_estimator, sc, 1)
-        obs2 = ObservationRecipe.observation(covar_estimator, sc, 2)
-
-        obs_series = EKP.ObservationSeries(
-            Dict(
-                "observations" => [obs1, obs2],
-                "names" => ["1", "2"],
-                "minibatcher" =>
-                    ClimaCalibrate.minibatcher_over_samples([1, 2], 1),
-            ),
-        )
-
-        eki = EKP.EnsembleKalmanProcess(
-            obs_series,
-            EKP.TransformUnscented(prior, impose_prior = true),
-            verbose = true,
-            scheduler = EKP.DataMisfitController(on_terminate = "continue"),
-        )
-
-        G_ens = reshape(collect(100.0:147.0), 16, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
-
-        # Test OutputVar is constructed correctly
-        @test length(vars) == 2
-        for (i, var) in enumerate((time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            @test vars[i].dims["time"] == first(var.dims["time"], 4)
-        end
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
-
-        G_ens = reshape(collect(200.0:247.0), 16, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
-
-        # Test OutputVar is constructed correctly
-        @test length(vars) == 2
-        for (i, var) in enumerate((time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            @test vars[i].dims["time"] == var.dims["time"][5:8]
-        end
-
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
-
-        # Test with multiple OutputVars with two iterations with a minibatch of
-        # size 2 and an observation series
-        obs3 = ObservationRecipe.observation(covar_estimator, sc, 3)
-        obs4 = ObservationRecipe.observation(covar_estimator, sc, 4)
-        obs_series = EKP.ObservationSeries(
-            Dict(
-                "observations" => [obs1, obs2, obs3, obs4],
-                "names" => ["1", "2", "3", "4"],
-                "minibatcher" => ClimaCalibrate.minibatcher_over_samples(
-                    [1, 2, 3, 4],
-                    2,
-                ),
-            ),
-        )
-
-        eki = EKP.EnsembleKalmanProcess(
-            obs_series,
-            EKP.TransformUnscented(prior, impose_prior = true),
-            verbose = true,
-            scheduler = EKP.DataMisfitController(on_terminate = "continue"),
-        )
-
-        G_ens = reshape(collect(1.0:96.0), 32, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
-
-        # Test OutputVar is constructed correctly
-        @test length(vars) == 4
-        for (i, var) in enumerate((time_var, lon_var, time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            if i in (1, 2)
-                @test vars[i].dims["time"] == var.dims["time"][1:4]
-            elseif i in (3, 4)
-                @test vars[i].dims["time"] == var.dims["time"][5:8]
-            else
-                error("You are not supposed to be here!")
-            end
-        end
-
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:16, :], dims = 2), 3, 4)
-        @test vars[3].data == vec(mean(G_ens[17:20, :], dims = 2))
-        @test vars[4].data == reshape(mean(G_ens[21:end, :], dims = 2), 3, 4)
-
-        # Another iteration
-        G_ens = reshape(collect(100.0:195.0), 32, 3)
-        EKP.update_ensemble!(eki, G_ens)
-        vars = ObservationRecipe.reconstruct_g_mean_final(eki)
-
-        # Test OutputVar is constructed correctly
-        @test length(vars) == 4
-        for (i, var) in enumerate((time_var, lon_var, time_var, lon_var))
-            @test vars[i].attributes == var.attributes
-            @test vars[i].dim_attributes == var.dim_attributes
-            if i in (1, 2)
-                @test vars[i].dims["time"] == var.dims["time"][9:12]
-            elseif i in (3, 4)
-                @test vars[i].dims["time"] == var.dims["time"][13:16]
-            else
-                error("You are not supposed to be here!")
-            end
-        end
-
-        @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
-        @test vars[2].data == reshape(mean(G_ens[5:16, :], dims = 2), 3, 4)
-        @test vars[3].data == vec(mean(G_ens[17:20, :], dims = 2))
-        @test vars[4].data == reshape(mean(G_ens[21:end, :], dims = 2), 3, 4)
+    # Test OutputVar is constructed correctly
+    @test length(vars) == 2
+    for (i, var) in enumerate((time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        @test vars[i].dims["time"] == first(var.dims["time"], 4)
     end
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
+
+    # Another iteration
+    G_ens = reshape(collect(100.0:147.0), 16, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+
+    # Test OutputVar is reconstructed correctly
+    @test length(vars) == 2
+    for (i, var) in enumerate((time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        @test vars[i].dims["time"] == first(var.dims["time"], 4)
+    end
+
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
+
+    # Test with multiple OutputVars with two iterations with a minibatch of
+    # size 1 and an observation series
+    obs1 = ObservationRecipe.observation(covar_estimator, sc, 1)
+    obs2 = ObservationRecipe.observation(covar_estimator, sc, 2)
+
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => [obs1, obs2],
+            "names" => ["1", "2"],
+            "minibatcher" =>
+                ClimaCalibrate.minibatcher_over_samples([1, 2], 1),
+        ),
+    )
+
+    eki = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+
+    G_ens = reshape(collect(100.0:147.0), 16, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+
+    # Test OutputVar is constructed correctly
+    @test length(vars) == 2
+    for (i, var) in enumerate((time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        @test vars[i].dims["time"] == first(var.dims["time"], 4)
+    end
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
+
+    G_ens = reshape(collect(200.0:247.0), 16, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+
+    # Test OutputVar is constructed correctly
+    @test length(vars) == 2
+    for (i, var) in enumerate((time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        @test vars[i].dims["time"] == var.dims["time"][5:8]
+    end
+
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:end, :], dims = 2), 3, 4)
+
+    # Test with multiple OutputVars with two iterations with a minibatch of
+    # size 2 and an observation series
+    obs3 = ObservationRecipe.observation(covar_estimator, sc, 3)
+    obs4 = ObservationRecipe.observation(covar_estimator, sc, 4)
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => [obs1, obs2, obs3, obs4],
+            "names" => ["1", "2", "3", "4"],
+            "minibatcher" =>
+                ClimaCalibrate.minibatcher_over_samples([1, 2, 3, 4], 2),
+        ),
+    )
+
+    eki = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior, impose_prior = true),
+        verbose = true,
+        scheduler = EKP.DataMisfitController(on_terminate = "continue"),
+    )
+
+    G_ens = reshape(collect(1.0:96.0), 32, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+
+    # Test OutputVar is constructed correctly
+    @test length(vars) == 4
+    for (i, var) in enumerate((time_var, lon_var, time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        if i in (1, 2)
+            @test vars[i].dims["time"] == var.dims["time"][1:4]
+        elseif i in (3, 4)
+            @test vars[i].dims["time"] == var.dims["time"][5:8]
+        else
+            error("You are not supposed to be here!")
+        end
+    end
+
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:16, :], dims = 2), 3, 4)
+    @test vars[3].data == vec(mean(G_ens[17:20, :], dims = 2))
+    @test vars[4].data == reshape(mean(G_ens[21:end, :], dims = 2), 3, 4)
+
+    # Another iteration
+    G_ens = reshape(collect(100.0:195.0), 32, 3)
+    EKP.update_ensemble!(eki, G_ens)
+    vars = ObservationRecipe.reconstruct_g_mean_final(eki)
+
+    # Test OutputVar is constructed correctly
+    @test length(vars) == 4
+    for (i, var) in enumerate((time_var, lon_var, time_var, lon_var))
+        @test vars[i].attributes == var.attributes
+        @test vars[i].dim_attributes == var.dim_attributes
+        if i in (1, 2)
+            @test vars[i].dims["time"] == var.dims["time"][9:12]
+        elseif i in (3, 4)
+            @test vars[i].dims["time"] == var.dims["time"][13:16]
+        else
+            error("You are not supposed to be here!")
+        end
+    end
+
+    @test vars[1].data == vec(mean(G_ens[1:4, :], dims = 2))
+    @test vars[2].data == reshape(mean(G_ens[5:16, :], dims = 2), 3, 4)
+    @test vars[3].data == vec(mean(G_ens[17:20, :], dims = 2))
+    @test vars[4].data == reshape(mean(G_ens[21:end, :], dims = 2), 3, 4)
 end
 
 @testset "Reconstruct diagonal of covariance and OutputVars from observations" begin

--- a/test/observation_recipe.jl
+++ b/test/observation_recipe.jl
@@ -1186,6 +1186,38 @@ end
     end
 end
 
+@testset "Observation with OutputVars with no dimensions" begin
+    make_0d_var(val; attribs...) =
+        TemplateVar() |>
+        add_attribs(; units = "K", attribs...) |>
+        add_data(data = fill(val)) |>
+        initialize
+
+    ts_var = make_0d_var(300.0, short_name = "ts")
+    ta_var = make_0d_var(250.0, short_name = "ta")
+
+    covar_estimator = ObservationRecipe.ScalarCovariance(scalar = 2.0)
+    sample_collection = SampleBuilder.build_samples([ts_var, ta_var])
+    obs = ObservationRecipe.observation(covar_estimator, sample_collection, 1)
+
+    @test obs.samples[1] == Float32[300.0, 250.0]
+    @test EKP.get_obs_noise_cov(obs) == Diagonal(Float32[2.0, 2.0])
+    @test obs.names == ["ts;ta"]
+
+    pkgversion(ClimaAnalysis) > v"0.5.23" || return
+
+    # Reconstruct the 0-dimensional OutputVars from the observation
+    reconstructed_vars = ObservationRecipe.reconstruct_vars(obs)
+    @test [ndims(var.data) for var in reconstructed_vars] == [0, 0]
+    @test [only(var.data) for var in reconstructed_vars] == [300.0f0, 250.0f0]
+    @test ClimaAnalysis.short_name.(reconstructed_vars) == ["ts", "ta"]
+
+    # Reconstruct the diagonal of the covariance matrix
+    reconstructed_cov_vars = ObservationRecipe.reconstruct_diag_cov(obs)
+    @test [ndims(var.data) for var in reconstructed_cov_vars] == [0, 0]
+    @test [only(var.data) for var in reconstructed_cov_vars] == [2.0f0, 2.0f0]
+end
+
 @testset "Short names of observation" begin
     if pkgversion(EnsembleKalmanProcesses) > v"2.4.2"
         time = ClimaAnalysis.Utils.date_to_time.(

--- a/test/sample_builder.jl
+++ b/test/sample_builder.jl
@@ -662,6 +662,33 @@ end
     )
 end
 
+@testset "Samples from OutputVars with no dimensions" begin
+    make_0d_var(val; attribs...) =
+        TemplateVar() |>
+        add_attribs(; units = "K", attribs...) |>
+        add_data(data = fill(val)) |>
+        initialize
+
+    var_samples =
+        [make_0d_var(10.0 * i + j, short_name = "var$j") for j in 1:2, i in 1:3]
+    sample_collection = SampleBuilder.build_samples(var_samples)
+    @test SampleBuilder.get_samples(sample_collection) ==
+          Float32[11.0 21.0 31.0; 12.0 22.0 32.0]
+    @test SampleBuilder.num_samples(sample_collection) == 3
+
+    pkgversion(ClimaAnalysis) > v"0.5.23" || return
+
+    # Reconstruct 0-dimensional OutputVars from a column
+    reconstructed_col = SampleBuilder.reconstruct_col(sample_collection, 2)
+    @test [ndims(var.data) for var in reconstructed_col] == [0, 0]
+    @test [only(var.data) for var in reconstructed_col] == [21.0f0, 22.0f0]
+    for (reconstructed, var) in zip(reconstructed_col, var_samples[:, 2])
+        @test reconstructed.attributes == var.attributes
+        @test reconstructed.dims == var.dims
+        @test reconstructed.dim_attributes == var.dim_attributes
+    end
+end
+
 @testset "Show" begin
     lat = [-90.0, -30.0, 30.0, 90.0]
     lon = [-60.0, -30.0, 0.0, 30.0, 60.0]


### PR DESCRIPTION
This PR fixes a bug in `SampleBuilder.build_samples` for zero dimensional `OutputVar`s.

This PR also removes the unnecessary `pkgversion` checks for EnsembleKalmanProcesses because the compat was updated a while back to disallow the versions that the `pkgversion` check for.