### PR TITLE
Keep logs for WorkerBackend

### DIFF
--- a/src/backends/workers.jl
+++ b/src/backends/workers.jl
@@ -336,7 +336,10 @@ end
 function default_worker_output_base(params, exehome, jobname)
     haskey(params, :o) && return params[:o]
     haskey(params, :output) && return params[:output]
-    return joinpath(mktempdir(exehome; prefix = ".julia_worker_"), jobname)
+    # Keep the worker logs after the main process exit to make it easier to
+    # debug a calibration
+    dir = mktempdir(exehome; prefix = ".julia_worker_", cleanup = false)
+    return joinpath(dir, jobname)
 end
 
 """


### PR DESCRIPTION
This PR makes it so the logs are not cleaned up at the end of the Julia process.